### PR TITLE
fix warining about possible unintitialized variables

### DIFF
--- a/events.c
+++ b/events.c
@@ -370,6 +370,7 @@ void motion_notify(xcb_generic_event_t *evt)
                     h = rect.height + delta_y;
                     break;
                 case BOTTOM_RIGHT:
+                default:
                     x = rect.x;
                     y = rect.y;
                     w = rect.width + delta_x;


### PR DESCRIPTION
this came up when compiling with `CFLAGS += -Os`  `LDFLAGS += -s` 
all it needs is a default case so that the compiler can ensure that the vars are initialized 
even though at least one case will always match.
