### PR TITLE
Don't skip propterty_notify for focused window

### DIFF
--- a/events.c
+++ b/events.c
@@ -188,8 +188,6 @@ void property_notify(xcb_generic_event_t *evt)
 
     window_location_t loc;
     if (locate_window(e->window, &loc)) {
-        if (loc.node == loc.desktop->focus)
-            return;
         if (xcb_icccm_get_wm_hints_reply(dpy, xcb_icccm_get_wm_hints(dpy, e->window), &hints, NULL) == 1) {
             loc.node->client->urgent = (hints.flags & XCB_ICCCM_WM_HINT_X_URGENCY);
             put_status();


### PR DESCRIPTION
When receiving a property_notify event, ensure we update the focused
window(s) as well, and don't bail early.  If we skip the focused window then
urgency hint properties on focused windows on an unfocused monitor are
skipped.

This currently happens when there's a single window on an unfocused monitor
which then becomes focused by switching monitors, and the event is never
received.
