### PR TITLE
Fix drawing of urgency border colour

### DIFF
--- a/window.c
+++ b/window.c
@@ -392,6 +392,8 @@ uint32_t get_main_border_color(client_t *c, bool focused_window, bool focused_mo
     } else if (focused_window) {
         if (c->locked)
             return active_locked_border_color_pxl;
+        else if (c->urgent)
+            return urgent_border_color_pxl;
         else
             return active_border_color_pxl;
     } else {


### PR DESCRIPTION
It looks as though commit f37c14902fd639b87090659433d815f20fe3a42a
introduced a regression in the way urgency borders are rendered.  Because
each window is considered across all desktops for monitors, we must now
augment the checking of an urgent client when looking up the border colours
for focused windows also.

Without this, a single window on a desk on an unfocused monitor will be
correctly set as having an urgent hint, but its borders will not pick up on
any urgent border colour settings.
