### PR TITLE
Add --next/--prev options to 'send_to_monitor'

### DIFF
--- a/types.h
+++ b/types.h
@@ -43,7 +43,9 @@ typedef enum {
 
 typedef enum {
     SEND_OPTION_FOLLOW,
-    SEND_OPTION_DONT_FOLLOW
+    SEND_OPTION_DONT_FOLLOW,
+    SEND_OPTION_NEXT,
+    SEND_OPTION_PREV
 } send_option_t;
 
 typedef enum {


### PR DESCRIPTION
This teaches the send_to_monitor command to send a client to either the
next/prev monitor rather than having to always specify a named monitor.
Such options are useful to be able to send clients to monitors relative to
their own position.
