### PR TITLE
Don't clobber system build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ VERSION = 0.7
 
 CC      = gcc
 LIBS    = -lm -lxcb -lxcb-icccm -lxcb-ewmh -lxcb-randr
-CFLAGS  = -std=c99 -pedantic -Wall -Wextra -I$(PREFIX)/include
+CFLAGS  += -std=c99 -pedantic -Wall -Wextra -I$(PREFIX)/include
 CFLAGS  += -D_POSIX_C_SOURCE=200112L -DVERSION=\"$(VERSION)\"
-LDFLAGS = -L$(PREFIX)/lib
+LDFLAGS += -L$(PREFIX)/lib
 
 PREFIX    ?= /usr/local
 BINPREFIX = $(PREFIX)/bin


### PR DESCRIPTION
Currently bspwm clobbers system build flags. This prevents stack-smashing protection and other compiler features from being applied.
