### PR TITLE
Arrange after killing a window

### DIFF
--- a/messages.c
+++ b/messages.c
@@ -55,7 +55,7 @@ void process_message(char *msg, char *rsp)
     } else if (strcmp(cmd, "close") == 0) {
         window_close(mon->desk->focus);
     } else if (strcmp(cmd, "kill") == 0) {
-        window_kill(mon->desk, mon->desk->focus);
+        window_kill(mon, mon->desk, mon->desk->focus);
     } else if (strcmp(cmd, "rotate") == 0) {
         char *deg = strtok(NULL, TOK_SEP);
         if (deg != NULL) {

--- a/window.c
+++ b/window.c
@@ -328,7 +328,7 @@ void window_close(node_t *n)
     xcb_send_event(dpy, false, win, XCB_EVENT_MASK_NO_EVENT, (char *) &e);
 }
 
-void window_kill(desktop_t *d, node_t *n)
+void window_kill(monitor_t *m, desktop_t *d, node_t *n)
 {
     if (n == NULL)
         return;
@@ -338,6 +338,7 @@ void window_kill(desktop_t *d, node_t *n)
 
     xcb_kill_client(dpy, win);
     remove_node(d, n);
+    arrange(m, d);
 }
 
 void toggle_fullscreen(desktop_t *d, node_t *n)

--- a/window.h
+++ b/window.h
@@ -24,7 +24,7 @@ void update_floating_rectangle(client_t *);
 void query_pointer(xcb_window_t *, xcb_point_t *);
 void list_windows(char *);
 void window_close(node_t *);
-void window_kill(desktop_t *, node_t *);
+void window_kill(monitor_t *, desktop_t *, node_t *);
 void toggle_fullscreen(desktop_t *, node_t *);
 void toggle_floating(desktop_t *, node_t *);
 void toggle_locked(monitor_t *, desktop_t *, node_t *);


### PR DESCRIPTION
When a window is killed, the unmap event is never fired leaving a hole
in the layout. This commit closes that hole by manually calling arrange
after killing.
