### PR TITLE
Prevents focus change due to mouse jitter

### DIFF
--- a/bspwm.c
+++ b/bspwm.c
@@ -125,6 +125,7 @@ void init(void)
     mon = last_mon = mon_head = mon_tail = NULL;
     rule_head = rule_tail = NULL;
     status_fifo = NULL;
+    last_motion_time = last_motion_x = last_motion_y = 0;
     randr_base = 0;
     visible = true;
     exit_status = 0;

--- a/events.c
+++ b/events.c
@@ -41,7 +41,7 @@ void handle_event(xcb_generic_event_t *evt)
             enter_notify(evt);
             break;
         case XCB_MOTION_NOTIFY:
-            motion_notify();
+            motion_notify(evt);
             break;
         default:
             if (randr && resp_type == randr_base + XCB_RANDR_SCREEN_CHANGE_NOTIFY)
@@ -239,9 +239,23 @@ void enter_notify(xcb_generic_event_t *evt)
     enable_motion_recorder();
 }
 
-void motion_notify(void)
+void motion_notify(xcb_generic_event_t *evt)
 {
     PUTS("motion notify");
+
+    xcb_motion_notify_event_t *e = (xcb_motion_notify_event_t *) evt;
+
+    int dtime = e->time - last_motion_time;
+    if (dtime > 1000) {
+        last_motion_time = e->time;
+        last_motion_x = e->event_x;
+        last_motion_y = e->event_y;
+        return;
+    }
+
+    int mdist = abs(e->event_x - last_motion_x) + abs(e->event_y - last_motion_y);
+    if (mdist < 10)
+        return;
 
     disable_motion_recorder();
 

--- a/events.h
+++ b/events.h
@@ -5,6 +5,8 @@
 #include <xcb/xcb_event.h>
 
 uint8_t randr_base;
+uint16_t last_motion_x, last_motion_y;
+xcb_timestamp_t last_motion_time;
 
 void handle_event(xcb_generic_event_t *);
 void map_request(xcb_generic_event_t *);
@@ -14,7 +16,7 @@ void configure_request(xcb_generic_event_t *);
 void client_message(xcb_generic_event_t *);
 void property_notify(xcb_generic_event_t *);
 void enter_notify(xcb_generic_event_t *);
-void motion_notify(void);
+void motion_notify(xcb_generic_event_t *);
 void handle_state(monitor_t *, desktop_t *, node_t *, xcb_atom_t, unsigned int);
 void grab_pointer(pointer_action_t);
 void track_pointer(int, int);


### PR DESCRIPTION
Yet another request...

This causes the `focus_follows_pointer` logic to ignore small mouse
jitters. This means that accidentally touching a laptop's trackpad
doesn't cause the focus to switch.

This patch prevents the pointer from causing a focus switch if the
pointer is moved fewer than 10 "Manhattan distance" (`dx+dy`) pixels
within a second.

I can make it configurable if you want but 10px in 1s is a pretty reasonable default.
