### PR TITLE
Apply modifiers to all objects

### DIFF
--- a/tree.h
+++ b/tree.h
@@ -3,6 +3,8 @@
 
 #define GROWTH_FACTOR  1.1
 
+bool node_matches(node_t *, node_t *, client_select_t);
+bool desktop_matches(desktop_t *, desktop_select_t);
 void arrange(monitor_t *, desktop_t *);
 void apply_layout(monitor_t *, desktop_t *, node_t *, xcb_rectangle_t, xcb_rectangle_t);
 void focus_node(monitor_t *, desktop_t *, node_t *);
@@ -13,10 +15,10 @@ void swap_nodes(node_t *, node_t *);
 void pseudo_focus(desktop_t *, node_t *);
 void update_current(void);
 node_t *find_fence(node_t *, direction_t);
-node_t *nearest_neighbor(desktop_t *, node_t *, direction_t);
-node_t *nearest_from_distance(desktop_t *, node_t *, direction_t);
-node_t *nearest_from_history(focus_history_t *, node_t *, direction_t);
-node_t *find_biggest(desktop_t *);
+node_t *nearest_neighbor(desktop_t *, node_t *, direction_t, client_select_t);
+node_t *nearest_from_distance(desktop_t *, node_t *, direction_t, client_select_t);
+node_t *nearest_from_history(focus_history_t *, node_t *, direction_t, client_select_t);
+node_t *find_biggest(desktop_t *, node_t *, client_select_t);
 bool is_leaf(node_t *);
 bool is_tiled(client_t *);
 bool is_floating(client_t *);
@@ -45,7 +47,7 @@ void transfer_node(monitor_t *, desktop_t *, monitor_t *, desktop_t *, node_t *)
 void transplant_node(monitor_t *, desktop_t *, node_t *, node_t *);
 void select_monitor(monitor_t *);
 void select_desktop(monitor_t *, desktop_t *);
-monitor_t *nearest_monitor(monitor_t *, direction_t);
+monitor_t *nearest_monitor(monitor_t *, direction_t, desktop_select_t);
 node_t *closest_node(desktop_t *, node_t *, cycle_dir_t, client_select_t);
 desktop_t *closest_desktop(monitor_t *, desktop_t *, cycle_dir_t, desktop_select_t);
 monitor_t *closest_monitor(monitor_t *, cycle_dir_t, desktop_select_t);


### PR DESCRIPTION
This patch applies the modifiers to all selectors. This change allows for commands like `window -f biggest.like` (focus the biggest like window), and queries like `query -D -d focused.free` (is the current desktop free).

Please check the direction logic. I don't know if I understood it correctly.

Window:
- cycle                : no change
- direction (history)  : only consider matching nodes
- direction (distance) : only consider matching nodes
- direction (normal)   : match or NULL
- last                 : walk history
- focused              : match or NULL
- biggest              : find biggest matching

Desktop:
- cycle                : no change
- focused              : match or NULL
- last                 : match or NULL

Monitor:
- cycle                : no change
- direction            : only consider matching nodes
- last                 : match or NULL
- focused              : match or NULL
