### PR TITLE
Allow overriding compiler.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.7
 
-CC      = gcc
+CC      ?= gcc
 LIBS    = -lm -lxcb -lxcb-icccm -lxcb-ewmh -lxcb-randr
 CFLAGS  += -std=c99 -pedantic -Wall -Wextra -I$(PREFIX)/include
 CFLAGS  += -D_POSIX_C_SOURCE=200112L -DVERSION=\"$(VERSION)\"


### PR DESCRIPTION
Let the user override the `CC` makefile variable.
