### PR TITLE
Add a rule to disable management completely

### DIFF
--- a/messages.c
+++ b/messages.c
@@ -504,6 +504,8 @@ bool cmd_rule(char **args, int num, char *rsp) {
                     rule->effect.follow = true;
                 } else if (streq("--focus", *args)) {
                     rule->effect.focus = true;
+                } else if (streq("--no-manage", *args)) {
+                    rule->effect.nomanage = true;
                 } else if (streq("-d", *args) || streq("--desktop", *args)) {
                     num--, args++;
                     if (num < 1) {

--- a/rules.c
+++ b/rules.c
@@ -121,6 +121,8 @@ void handle_rules(xcb_window_t win, monitor_t **m, desktop_t **d, bool *floating
                 *follow = true;
             if (efc.focus)
                 *takes_focus = true;
+            if (efc.nomanage) 
+                *manage = false;
             if (efc.desc[0] != '\0') {
                 coordinates_t ref = {*m, *d, NULL};
                 coordinates_t loc;
@@ -149,6 +151,8 @@ void list_rules(char *pattern, char *rsp)
             strncat(rsp, " --follow", REMLEN(rsp));
         if (r->effect.focus)
             strncat(rsp, " --focus", REMLEN(rsp));
+        if (r->effect.nomanage)
+            strncat(rsp, " --no-manage", REMLEN(rsp));
         if (r->effect.desc[0] != '\0') {
             snprintf(line, sizeof(line), " -d %s", r->effect.desc);
             strncat(rsp, line, REMLEN(rsp));

--- a/types.h
+++ b/types.h
@@ -221,6 +221,7 @@ typedef struct {
     bool floating;
     bool follow;
     bool focus;
+    bool nomanage;
     char desc[MAXLEN];
 } rule_effect_t;
 


### PR DESCRIPTION
Since the functionality is already there, I think it makes sense to offer it as a rule as well.
I needed this for "screenkeys", which displays pressed keys for a screencast.
