### PR TITLE
Change order of dzen2 segments

### DIFF
--- a/examples/panel/panel_dzen2
+++ b/examples/panel/panel_dzen2
@@ -101,5 +101,5 @@ while read -r line ; do
             center_indent=$(( (screen_width - center_width) / 2 ))
         fi
     fi
-    printf "%s\n" "^pa($center_indent)$title^pa($left_indent)$wm_infos^pa($right_indent)$sys_infos"
+    printf "%s\n" "^pa($left_indent)$wm_infos^pa($center_indent)$title^pa($right_indent)$sys_infos"
 done


### PR DESCRIPTION
Using the current example for dzen2, if you set a background colour for title (different from panel background), this colour leaks to the left of the desktops list.

The proposed change should fix that.
