### PR TITLE
Relatively translate floating clients to the correct monitor

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -105,6 +105,26 @@ void translate_position(monitor_t *ms, monitor_t *md, node_t *n)
     }
 }
 
+void translate_client(monitor_t *ms, monitor_t *md, client_t *c) {
+
+    int xoff = c->floating_rectangle.x - ms->rectangle.x;
+    int yoff = c->floating_rectangle.y - ms->rectangle.y;
+
+    int xnum = xoff*(md->rectangle.width - c->floating_rectangle.width);
+    int ynum = yoff*(md->rectangle.height - c->floating_rectangle.height);
+
+    int xden = ms->rectangle.width - c->floating_rectangle.width;
+    int yden = ms->rectangle.height - c->floating_rectangle.height;
+
+    /* xden and yden can be zero if the window is fullscreen */
+    int xoff_new = xden == 0 ? 0 : xnum/xden;
+    int yoff_new = yden == 0 ? 0 : ynum/yden;
+
+    c->floating_rectangle.x = md->rectangle.x + xoff_new;
+    c->floating_rectangle.y = md->rectangle.y + yoff_new;
+}
+
+
 void update_root(monitor_t *m)
 {
     xcb_rectangle_t rect = m->rectangle;

--- a/monitor.h
+++ b/monitor.h
@@ -31,6 +31,7 @@ monitor_t *make_monitor(xcb_rectangle_t rect);
 monitor_t *find_monitor(char *name);
 monitor_t *get_monitor_by_id(xcb_randr_output_t id);
 void translate_position(monitor_t *ms, monitor_t *md, node_t *n);
+void translate_client(monitor_t *ms, monitor_t *md, client_t *n);
 void update_root(monitor_t *m);
 void focus_monitor(monitor_t *m);
 monitor_t *add_monitor(xcb_rectangle_t rect);

--- a/window.c
+++ b/window.c
@@ -73,8 +73,7 @@ void manage_window(monitor_t *m, desktop_t *d, xcb_window_t win)
     client_t *c = make_client(win);
     update_floating_rectangle(c);
     if (fresh) {
-        c->floating_rectangle.x += m->rectangle.x;
-        c->floating_rectangle.y += m->rectangle.y;
+        translate_client(underlying_monitor(c), m, c);
     }
     c->frame = frame;
 


### PR DESCRIPTION
Here is a sketch of what I was trying to get at in #80. Basically, it translates the window from the origin monitor to the correct monitor preserving the _relative_ corner offsets. In other words, leave w<sub>w</sub> and h<sub>w</sub> unchanged and let **a**/**b** == **c**/**d** (where **a**, **b**, **c**, and **d** are vectors).
![geometry](https://f.cloud.github.com/assets/310393/1414024/dc199ff2-3e63-11e3-92cd-137c23a9fd48.png)

You'll probably want to merge `translate_client` with `translate_position`. I didn't try to do this as I don't want to break something else.
