### PR TITLE
Added the config option 'tmux_split'.

### DIFF
--- a/messages.c
+++ b/messages.c
@@ -972,6 +972,7 @@ bool set_setting(coordinates_t loc, char *name, char *value)
 		SETBOOL(history_aware_focus)
 		SETBOOL(ignore_ewmh_focus)
 		SETBOOL(remove_disabled_monitor)
+		SETBOOL(tmux_split)
 #undef SETBOOL
 	} else {
 		return false;
@@ -1043,6 +1044,7 @@ bool get_setting(coordinates_t loc, char *name, char* rsp)
 	GETBOOL(history_aware_focus)
 	GETBOOL(ignore_ewmh_focus)
 	GETBOOL(remove_disabled_monitor)
+	GETBOOL(tmux_split)
 #undef GETBOOL
 	else
 		return false;

--- a/settings.c
+++ b/settings.c
@@ -73,4 +73,5 @@ void load_settings(void)
 	history_aware_focus = HISTORY_AWARE_FOCUS;
 	ignore_ewmh_focus = IGNORE_EWMH_FOCUS;
 	remove_disabled_monitor = REMOVE_DISABLED_MONITOR;
+	tmux_split = TMUX_SPLIT;
 }

--- a/settings.h
+++ b/settings.h
@@ -65,6 +65,8 @@
 #define IGNORE_EWMH_FOCUS        false
 #define REMOVE_DISABLED_MONITOR  false
 
+#define TMUX_SPLIT               false
+
 char external_rules_command[MAXLEN];
 char status_prefix[MAXLEN];
 
@@ -95,6 +97,7 @@ bool auto_cancel;
 bool history_aware_focus;
 bool ignore_ewmh_focus;
 bool remove_disabled_monitor;
+bool tmux_split;
 
 void run_config(void);
 void load_settings(void);

--- a/tree.c
+++ b/tree.c
@@ -175,6 +175,10 @@ void insert_node(monitor_t *m, desktop_t *d, node_t *n, node_t *f)
 		}
 		n->parent = c;
 		c->birth_rotation = f->birth_rotation;
+
+		if (f->split_mode == MODE_AUTOMATIC && tmux_split)
+			f->split_mode = MODE_SEMI_AUTOMATIC;
+
 		switch (f->split_mode) {
 			case MODE_AUTOMATIC:
 				if (p == NULL) {
@@ -215,6 +219,11 @@ void insert_node(monitor_t *m, desktop_t *d, node_t *n, node_t *f)
 					n->birth_rotation = rot;
 				}
 				break;
+			case MODE_SEMI_AUTOMATIC:
+				if (f->rectangle.height > f->rectangle.width)
+					f->split_dir =  DIR_DOWN;
+				else
+					f->split_dir = DIR_RIGHT;
 			case MODE_MANUAL:
 				if (p != NULL) {
 					if (is_first_child(f))

--- a/types.h
+++ b/types.h
@@ -45,6 +45,7 @@ typedef enum {
 
 typedef enum {
 	MODE_AUTOMATIC,
+	MODE_SEMI_AUTOMATIC,
 	MODE_MANUAL
 } split_mode_t;
 


### PR DESCRIPTION
If true, the focussed window will be split as if in manual mode, and the direction will depend on how much space is remaining (if the focussed window is taller than wide, split down. if wider than tall, split right) instead of the normal automatic mode behavior.
