### PR TITLE
Make colors work in panel_bar

### DIFF
--- a/examples/panel/panel_bar
+++ b/examples/panel/panel_bar
@@ -2,6 +2,8 @@
 #
 # Example panel for LemonBoy's bar
 
+. panel_colors
+
 while read -r line ; do
 	case $line in
 		S*)


### PR DESCRIPTION
I realised the colours weren't sourced, causing the bar not to work correctly.
