### PR TITLE
Protect mouse pointer when pointer_follows_focus set

### DIFF
--- a/events.c
+++ b/events.c
@@ -347,15 +347,18 @@ void motion_notify(xcb_generic_event_t *evt)
 	xcb_point_t pt = {e->root_x, e->root_y};
 	query_pointer(&win, NULL);
 
-	bool backup = pointer_follows_monitor;
+	bool pfm_backup = pointer_follows_monitor;
+	bool pff_backup = pointer_follows_focus;
 	auto_raise = false;
 	pointer_follows_monitor = false;
+	pointer_follows_focus = false;
 	if (!window_focus(win)) {
 		monitor_t *m = monitor_from_point(pt);
 		if (m != NULL && m != mon)
 			focus_node(m, m->desk, m->desk->focus);
 	}
-	pointer_follows_monitor = backup;
+	pointer_follows_monitor = pfm_backup;
+	pointer_follows_focus = pff_backup;
 	auto_raise = true;
 }
 


### PR DESCRIPTION
When dialog window shows, I cannot move pointer outside this dialog window
because when I move it, it jumps in window's center (again on dialog).
So, this commit disables pff when mouse focus event happen and enables
after.
