### PR TITLE
Work around null pointer dereference

### DIFF
--- a/tree.c
+++ b/tree.c
@@ -168,11 +168,15 @@ void insert_node(monitor_t *m, desktop_t *d, node_t *n, node_t *f)
 					p = f->parent;
 				}
 				f->split_mode = MODE_MANUAL;
-				xcb_rectangle_t rect = f->client->tiled_rectangle;
-				f->split_dir = (rect.width >= rect.height ? DIR_LEFT : DIR_UP);
-				if (f->client->private) {
-					get_opposite(f->split_dir, &f->split_dir);
-					update_privacy_level(f, false);
+				if (f->client != NULL) {
+					xcb_rectangle_t rect = f->client->tiled_rectangle;
+					f->split_dir = (rect.width >= rect.height ? DIR_LEFT : DIR_UP);
+					if (f->client->private) {
+						get_opposite(f->split_dir, &f->split_dir);
+						update_privacy_level(f, false);
+					}
+				} else {
+					f->split_dir = DIR_UP;
 				}
 			}
 		}


### PR DESCRIPTION
The following steps produce a segmentation fault:

    * Open two tiled windows
    * Toggle private mode for one window
    * Spawn a floating window
    * Then spawn another

gdb output with -ggdb:

```
Program received signal SIGSEGV, Segmentation fault.
0x0000000000407b39 in insert_node (m=0xeff400, d=0xeff480, n=0xefe940, f=0xeff710) at tree.c:171
171                                     xcb_rectangle_t rect = f->client->tiled_rectangle;
(gdb) p *f
$1 = {
  split_type = TYPE_HORIZONTAL,
  split_ratio = 0.5,
  split_mode = MODE_MANUAL,
  split_dir = DIR_RIGHT,
  birth_rotation = 0,
  rectangle = {
    x = 844,
    y = 8,
    width = 836,
    height = 1022
  },
  vacant = false,
  privacy_level = 0,
  first_child = 0xeff6b0,
  second_child = 0xeff350,
  parent = 0xeff560,
  client = 0x0
}
(gdb)
```

Here f->client is NULL, but we try to read f->client->tiled_rectangle.

This patch provides a simple workaround by choosing a default split
direction (DIR_UP) when the client window geometry is unknown.

END-PATCH-HEADER

I don't think this is the correct solution for this problem, but I
thought it would be useful to start a discussion with a proposal.

Thanks for the great window manager!
