### PR TITLE
Add alternative split mode

### DIFF
--- a/messages.c
+++ b/messages.c
@@ -1039,6 +1039,7 @@ int set_setting(coordinates_t loc, char *name, char *value)
 		SETBOOL(focus_by_distance)
 		SETBOOL(ignore_ewmh_focus)
 		SETBOOL(center_pseudo_tiled)
+		SETBOOL(enable_autosplit_mode)
 #undef SETBOOL
 #define SETMONBOOL(s) \
 	} else if (streq(#s, name)) { \
@@ -1129,6 +1130,8 @@ int get_setting(coordinates_t loc, char *name, FILE* rsp)
 	GETBOOL(remove_disabled_monitors)
 	GETBOOL(remove_unplugged_monitors)
 	GETBOOL(merge_overlapping_monitors)
+	GETBOOL(mode_alter)
+	GETBOOL(enable_autosplit_mode)
 #undef GETBOOL
 	else
 		return MSG_FAILURE;

--- a/messages.c
+++ b/messages.c
@@ -1130,7 +1130,6 @@ int get_setting(coordinates_t loc, char *name, FILE* rsp)
 	GETBOOL(remove_disabled_monitors)
 	GETBOOL(remove_unplugged_monitors)
 	GETBOOL(merge_overlapping_monitors)
-	GETBOOL(mode_alter)
 	GETBOOL(enable_autosplit_mode)
 #undef GETBOOL
 	else

--- a/settings.c
+++ b/settings.c
@@ -76,4 +76,6 @@ void load_settings(void)
 	remove_disabled_monitors = REMOVE_DISABLED_MONITORS;
 	remove_unplugged_monitors = REMOVE_UNPLUGGED_MONITORS;
 	merge_overlapping_monitors = MERGE_OVERLAPPING_MONITORS;
+
+	enable_autosplit_mode = ENABLE_AUTOSPLIT_MODE;
 }

--- a/settings.h
+++ b/settings.h
@@ -68,6 +68,8 @@
 #define REMOVE_UNPLUGGED_MONITORS   false
 #define MERGE_OVERLAPPING_MONITORS  false
 
+#define ENABLE_AUTOSPLIT_MODE       false
+
 char external_rules_command[MAXLEN];
 char status_prefix[MAXLEN];
 
@@ -106,6 +108,8 @@ bool center_pseudo_tiled;
 bool remove_disabled_monitors;
 bool remove_unplugged_monitors;
 bool merge_overlapping_monitors;
+
+bool enable_autosplit_mode;
 
 void run_config(void);
 void load_settings(void);

--- a/tree.c
+++ b/tree.c
@@ -182,6 +182,11 @@ void insert_node(monitor_t *m, desktop_t *d, node_t *n, node_t *f)
 			f = p;
 			p = f->parent;
 		}
+
+		if (enable_autosplit_mode && p != NULL && f->split_mode == MODE_AUTOMATIC){
+			f->split_mode = MODE_AUTOSPLIT;
+		}
+
 		n->parent = c;
 		c->birth_rotation = f->birth_rotation;
 		switch (f->split_mode) {
@@ -261,6 +266,30 @@ void insert_node(monitor_t *m, desktop_t *d, node_t *n, node_t *f)
 						c->first_child = f;
 						c->second_child = n;
 						break;
+				}
+				if (d->root == f)
+					d->root = c;
+				f->split_mode = MODE_AUTOMATIC;
+				break;
+			case MODE_AUTOSPLIT:
+				if (p != NULL) {
+					if (is_first_child(f))
+						p->first_child = c;
+					else
+						p->second_child = c;
+				}
+				c->split_ratio = f->split_ratio;
+				c->parent = p;
+				f->parent = c;
+				f->birth_rotation = 0;
+				if (f->rectangle.width > f->rectangle.height) {
+					c->split_type = TYPE_VERTICAL;
+					c->first_child = n;
+					c->second_child = f;
+				}else{
+					c->split_type = TYPE_HORIZONTAL;
+					c->first_child = f;
+					c->second_child = n;
 				}
 				if (d->root == f)
 					d->root = c;

--- a/types.h
+++ b/types.h
@@ -41,7 +41,8 @@ typedef enum {
 
 typedef enum {
 	MODE_AUTOMATIC,
-	MODE_MANUAL
+	MODE_MANUAL,
+	MODE_AUTOSPLIT
 } split_mode_t;
 
 typedef enum {


### PR DESCRIPTION
alternative mode of automatic tile windows, MODE_AUTOSPLIT, enables through:

bspc config enable_autosplit_mode   true   #default false

in this mode, creating a new tile the focused tile splits on the larger side(width or height) and doesn't shift as in standard AUTOMATIC mode. It looks like fixed MANUAL_SPLIT: if width > height, then preselect left side, if height > width, then preselect bottom.