### PR TITLE
Replaced broken old AUR link with up to date links to arch packages.

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -16,7 +16,8 @@
 
 - Arch Linux
 	- [bspwm-git](https://aur.archlinux.org/packages/bspwm-git)
-	- [bspwm](https://aur.archlinux.org/packages/bspwm)
+	- [bspwm (x86_64)](https://www.archlinux.org/packages/community/x86_64/bspwm/)
+	- [bspwm (i686)](https://www.archlinux.org/packages/community/i686/bspwm/)
 
 - Gentoo Linux
 	- [bspwm-git](https://github.com/milomouse/ebuilds)


### PR DESCRIPTION
I noticed the old AUR link was now broken, so I fixed it by providing up to date links.