### PR TITLE
Loads sxhkd at bspwm startup.

### DIFF
--- a/examples/bspwmrc
+++ b/examples/bspwmrc
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+sxhkd &
+
 bspc config border_width        2
 bspc config window_gap         12
 


### PR DESCRIPTION
Let's end up the drama about loading `sxhkd` at the same time than `bspwm`.

This is especially useful for Display Manager users who are not really used to how it works.

Linuxians not using any DM should just changed their `~/.xinit` or `~/.xprofile` or even `~/.profile` from

```bash
sxhkd &
exec bspwm
```

to

```bash
exec bspwm
```

I think this makes it easier to install and would end up the confusion for new comers while testing this window manager for the first when they come from DM environments. (Yes, I did get confused aswell. =P)