### PR TITLE
Change default behaviour to cancel repeated preselctions

### DIFF
--- a/messages.c
+++ b/messages.c
@@ -253,9 +253,14 @@ int cmd_window(char **args, int num)
 						if (sscanf(*args, "%lf", &rat) != 1 || rat <= 0 || rat >= 1)
 							return MSG_FAILURE;
 					}
-					trg.node->split_mode = MODE_MANUAL;
-					trg.node->split_dir = dir;
-					trg.node->split_ratio = rat;
+					if (trg.node->split_mode == MODE_MANUAL && dir == trg.node->split_dir && rat == trg.node->split_ratio) {
+						reset_mode(&trg);
+					}
+					else {
+						trg.node->split_mode = MODE_MANUAL;
+						trg.node->split_dir = dir;
+						trg.node->split_ratio = rat;
+					}
 					window_draw_border(trg.node, trg.desktop->focus == trg.node, mon == trg.monitor);
 				} else {
 					return MSG_FAILURE;


### PR DESCRIPTION
See 4fbd961

I don't see a situation where not being able to cancel a preselection makes sense. The user is instead forced to either

1. Install extra packages (`jshon`) and use unwieldy multi-line commands in a hotkey daemon to achieve the effect
2. Set up an entirely separate command for cancelling preselections

Increasing overhead or increasing complexity to disrupt workflow is not helpful.

It doesn't make sense to have the ability to preselect the same direction repeatedly.  The user doesn't *need* to be able to do that. The user does, however, *need* to be able to quickly cancel any accidental preselections.

Please consider including this as default behavior, or at least re-introducing the option. **Thank you.**