### PR TITLE
Add bspc pointer --track to example

### DIFF
--- a/examples/sxhkdrc
+++ b/examples/sxhkdrc
@@ -131,6 +131,11 @@ super + {Left,Down,Up,Right}
 # start move/resize
 super + button{1-3}
 	; bspc pointer -g {move,resize_side,resize_corner}
+	
+```
+super + !button{1-3}
+    bspc pointer --track %i %i
+```
 
 # end move/resize
 super + @button{1-3}


### PR DESCRIPTION
The current example configuration contains some lines in sxhkdrc that should give mouse support but
it doesn't work without the following lines

```
super + !button{1-3}
    bspc pointer --track %i %i
```

Partly discussed in #382 