### PR TITLE
Fix using uninitialized value

### DIFF
--- a/tree.c
+++ b/tree.c
@@ -622,6 +622,8 @@ client_t *make_client(void)
 	snprintf(c->class_name, sizeof(c->class_name), "%s", MISSING_VALUE);
 	snprintf(c->instance_name, sizeof(c->instance_name), "%s", MISSING_VALUE);
 	c->border_width = border_width;
+	c->urgent = false;
+	c->shown = false;
 	c->wm_flags = 0;
 	c->icccm_props.input_hint = true;
 	c->icccm_props.take_focus = false;


### PR DESCRIPTION
Currently with bspwm, the urgent member is read before being set.

Valgrind output:

```
==17037== Conditional jump or move depends on uninitialised value(s)
==17037==    at 0x409C06: focus_node (tree.c:503)
==17037==    by 0x40FF89: enter_notify (events.c:355)
==17037==    by 0x40F3C2: handle_event (events.c:61)
==17037==    by 0x404406: main (bspwm.c:180)
==17037==  Uninitialised value was created by a heap allocation
==17037==    at 0x4C2ABD0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17037==    by 0x40A0A0: make_client (tree.c:619)
==17037==    by 0x4117E0: manage_window (window.c:131)
==17037==    by 0x41142A: schedule_window (window.c:67)
==17037==    by 0x4124D2: adopt_orphans (window.c:391)
==17037==    by 0x417FC9: cmd_wm (messages.c:1132)
==17037==    by 0x413DAA: process_message (messages.c:100)
==17037==    by 0x413C22: handle_message (messages.c:81)
==17037==    by 0x4043A2: main (bspwm.c:170)
```

Note that setting `shown` may not be needed, but seems reasonable to clear for new clients.