### PR TITLE
Fix example panel scripts

### DIFF
--- a/examples/panel/panel
+++ b/examples/panel/panel
@@ -1,5 +1,8 @@
 #! /bin/sh
 
+export PATH=$PATH:"`dirname $0`"
+. profile
+
 if xdo id -a "$PANEL_WM_NAME" > /dev/null ; then
 	printf "%s\n" "The panel is already running." >&2
 	exit 1


### PR DESCRIPTION
Fix PATH to allow launching the panel scripts (fixes the `panel_colors not found`, etc.).
Source the profile file at top of `panel`, so xdo will execute the correct query (fixes the `panel already running` error).

Edit: I firstly thought that using `sh` was what broke the scripts, but it is not.