### PR TITLE
Remove rule key implication from config command.

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -2,12 +2,12 @@
 .\"     Title: bspwm
 .\"    Author: [see the "Author" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 11/12/2016
+.\"      Date: 11/13/2016
 .\"    Manual: Bspwm Manual
-.\"    Source: Bspwm 0.9.2-3-ga457474
+.\"    Source: Bspwm 0.9.2-5-gb14ec64
 .\"  Language: English
 .\"
-.TH "BSPWM" "1" "11/12/2016" "Bspwm 0\&.9\&.2\-3\-ga457474" "Bspwm Manual"
+.TH "BSPWM" "1" "11/13/2016" "Bspwm 0\&.9\&.2\-5\-gb14ec64" "Bspwm Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -952,9 +952,9 @@ List the rules\&.
 \fBGeneral Syntax\fR
 .RS 4
 .PP
-config [\-m \fIMONITOR_SEL\fR|\-d \fIDESKTOP_SEL\fR|\-n \fINODE_SEL\fR] <key> [<value>]
+config [\-m \fIMONITOR_SEL\fR|\-d \fIDESKTOP_SEL\fR|\-n \fINODE_SEL\fR] <setting> [<value>]
 .RS 4
-Get or set the value of <key>\&.
+Get or set the value of <setting>\&.
 .RE
 .RE
 .SS "Subscribe"

--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -566,8 +566,8 @@ Config
 General Syntax
 ^^^^^^^^^^^^^^
 
-config [-m 'MONITOR_SEL'|-d 'DESKTOP_SEL'|-n 'NODE_SEL'] <key> [<value>]::
-	Get or set the value of <key>.
+config [-m 'MONITOR_SEL'|-d 'DESKTOP_SEL'|-n 'NODE_SEL'] <setting> [<value>]::
+	Get or set the value of <setting>.
 
 Subscribe
 ~~~~~~~~~


### PR DESCRIPTION
From the `external_rules_command`: `the valid key/value pairs are given in the description of the rule command`. 

I (sleepily) misinterpreted config syntax into thinking I could use it in a rule-like fashion (because of the keyword `key`), I feel this edit removes ambiguity. 

