### PR TITLE
Support EWMH property _NET_DESKTOP_VIEWPORT

### DIFF
--- a/bspwm.c
+++ b/bspwm.c
@@ -240,6 +240,7 @@ void setup(void)
 	xcb_atom_t net_atoms[] = {ewmh->_NET_SUPPORTED,
 	                          ewmh->_NET_SUPPORTING_WM_CHECK,
 	                          ewmh->_NET_DESKTOP_NAMES,
+	                          ewmh->_NET_DESKTOP_VIEWPORT,
 	                          ewmh->_NET_NUMBER_OF_DESKTOPS,
 	                          ewmh->_NET_CURRENT_DESKTOP,
 	                          ewmh->_NET_CLIENT_LIST,
@@ -313,6 +314,7 @@ void setup(void)
 
 	ewmh_update_number_of_desktops();
 	ewmh_update_desktop_names();
+	ewmh_update_desktop_viewport();
 	ewmh_update_current_desktop();
 	xcb_get_input_focus_reply_t *ifo = xcb_get_input_focus_reply(dpy, xcb_get_input_focus(dpy), NULL);
 	if (ifo != NULL && (ifo->focus == XCB_INPUT_FOCUS_POINTER_ROOT || ifo->focus == XCB_NONE)) {

--- a/desktop.c
+++ b/desktop.c
@@ -196,6 +196,7 @@ bool transfer_desktop(monitor_t *ms, monitor_t *md, desktop_t *d)
 
 	ewmh_update_wm_desktops();
 	ewmh_update_desktop_names();
+	ewmh_update_desktop_viewport();
 	ewmh_update_current_desktop();
 
 	put_status(SBSC_MASK_DESKTOP_TRANSFER, "desktop_transfer 0x%08X 0x%08X 0x%08X\n", ms->id, d->id, md->id);
@@ -253,6 +254,7 @@ void add_desktop(monitor_t *m, desktop_t *d)
 	insert_desktop(m, d);
 	ewmh_update_number_of_desktops();
 	ewmh_update_desktop_names();
+	ewmh_update_desktop_viewport();
 	ewmh_update_wm_desktops();
 	put_status(SBSC_MASK_REPORT);
 }
@@ -312,6 +314,7 @@ void remove_desktop(monitor_t *m, desktop_t *d)
 	ewmh_update_current_desktop();
 	ewmh_update_number_of_desktops();
 	ewmh_update_desktop_names();
+	ewmh_update_desktop_viewport();
 
 	if (mon != NULL && m->desk == NULL) {
 		if (m == mon) {
@@ -435,6 +438,7 @@ bool swap_desktops(monitor_t *m1, desktop_t *d1, monitor_t *m2, desktop_t *d2)
 
 	ewmh_update_wm_desktops();
 	ewmh_update_desktop_names();
+	ewmh_update_desktop_viewport();
 	ewmh_update_current_desktop();
 
 	put_status(SBSC_MASK_REPORT);

--- a/ewmh.c
+++ b/ewmh.c
@@ -149,6 +149,24 @@ void ewmh_update_desktop_names(void)
 	xcb_ewmh_set_desktop_names(ewmh, default_screen, names_len, names);
 }
 
+void ewmh_update_desktop_viewport(void)
+{
+	uint32_t desktops_count = 0;
+	for (monitor_t *m = mon_head; m != NULL; m = m->next) {
+		for (desktop_t *d = m->desk_head; d != NULL; d = d->next) {
+			desktops_count++;
+		}
+	}
+	xcb_ewmh_coordinates_t coords[desktops_count];
+	uint16_t desktop = 0;
+	for (monitor_t *m = mon_head; m != NULL; m = m->next) {
+		for (desktop_t *d = m->desk_head; d != NULL; d = d->next) {
+			coords[desktop++] = (xcb_ewmh_coordinates_t){m->rectangle.x, m->rectangle.y};
+		}
+	}
+	xcb_ewmh_set_desktop_viewport(ewmh, default_screen, desktop, coords);
+}
+
 bool ewmh_handle_struts(xcb_window_t win)
 {
 	xcb_ewmh_wm_strut_partial_t struts;

--- a/ewmh.h
+++ b/ewmh.h
@@ -38,6 +38,7 @@ void ewmh_update_current_desktop(void);
 void ewmh_set_wm_desktop(node_t *n, desktop_t *d);
 void ewmh_update_wm_desktops(void);
 void ewmh_update_desktop_names(void);
+void ewmh_update_desktop_viewport(void);
 bool ewmh_handle_struts(xcb_window_t win);
 void ewmh_update_client_list(bool stacking);
 void ewmh_wm_state_update(node_t *n);

--- a/monitor.c
+++ b/monitor.c
@@ -337,6 +337,7 @@ bool swap_monitors(monitor_t *m1, monitor_t *m2)
 
 	ewmh_update_wm_desktops();
 	ewmh_update_desktop_names();
+	ewmh_update_desktop_viewport();
 	ewmh_update_current_desktop();
 
 	put_status(SBSC_MASK_REPORT);

--- a/restore.c
+++ b/restore.c
@@ -185,6 +185,7 @@ bool restore_tree(const char *file_path)
 	ewmh_update_number_of_desktops();
 	ewmh_update_current_desktop();
 	ewmh_update_desktop_names();
+	ewmh_update_desktop_viewport();
 
 	free(tokens);
 	free(json);


### PR DESCRIPTION
Add support for the EWMH property _NET_DESKTOP_VIEWPORT.

https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#idm140130317690112

Makes it possible to group _NET_DESKTOP_NAMES by viewport which makes them alot more useful.