### PR TITLE
Allow (+|-)fraction in "node --ratio" command

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -2,12 +2,12 @@
 .\"     Title: bspwm
 .\"    Author: [see the "Author" section]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 12/21/2016
+.\"      Date: 01/30/2017
 .\"    Manual: Bspwm Manual
-.\"    Source: Bspwm 0.9.2-18-g0d34170
+.\"    Source: Bspwm 0.9.2-25-g048230e
 .\"  Language: English
 .\"
-.TH "BSPWM" "1" "12/21/2016" "Bspwm 0\&.9\&.2\-18\-g0d34170" "Bspwm Manual"
+.TH "BSPWM" "1" "01/30/2017" "Bspwm 0\&.9\&.2\-25\-g048230e" "Bspwm Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -605,7 +605,7 @@ pixels horizontally and
 pixels vertically\&.
 .RE
 .PP
-\fB\-r\fR, \fB\-\-ratio\fR \fIRATIO\fR|(+|\-)\fIPIXELS\fR
+\fB\-r\fR, \fB\-\-ratio\fR \fIRATIO\fR|(+|\-)(\fIPIXELS\fR|\fIFRACTION\fR)
 .RS 4
 Set the splitting ratio of the selected node (0 <
 \fIRATIO\fR

--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -367,7 +367,7 @@ Commands
 *-z*, *--resize* top|left|bottom|right|top_left|top_right|bottom_right|bottom_left 'dx' 'dy'::
 	Resize the selected window by moving the given handle by 'dx' pixels horizontally and 'dy' pixels vertically.
 
-*-r*, *--ratio* 'RATIO'|(+|-)'PIXELS'::
+*-r*, *--ratio* 'RATIO'|(+|-)('PIXELS'|'FRACTION')::
 	Set the splitting ratio of the selected node (0 < 'RATIO' < 1).
 
 *-R*, *--rotate* '90|270|180'::

--- a/src/messages.c
+++ b/src/messages.c
@@ -438,10 +438,15 @@ void cmd_node(char **args, int num, FILE *rsp)
 				break;
 			}
 			if ((*args)[0] == '+' || (*args)[0] == '-') {
-				int pix;
-				if (sscanf(*args, "%i", &pix) == 1) {
-					int max = (trg.node->split_type == TYPE_HORIZONTAL ? trg.node->rectangle.height : trg.node->rectangle.width);
-					double rat = ((max * trg.node->split_ratio) + pix) / max;
+				float delta;
+				if (sscanf(*args, "%f", &delta) == 1) {
+					double rat = trg.node->split_ratio;
+					if (delta > -1 && delta < 1) {
+						rat += delta;
+					} else {
+						int max = (trg.node->split_type == TYPE_HORIZONTAL ? trg.node->rectangle.height : trg.node->rectangle.width);
+						rat = ((max * rat) + delta) / max;
+					}
 					if (rat > 0 && rat < 1) {
 						set_ratio(trg.node, rat);
 					} else {


### PR DESCRIPTION
As discussed in #609 this allows to change the ratio of a node by a fraction: `bspc node NODE_SEL --ratio +.1` will change the ratio from e.g. `0.5` to `0.6`.

The value passed on the command line is parsed as float, and if `-1 < value < 1` it is interpreted as a fraction instead of pixels. This means that the `--ratio +|-` command now accepts floats instead of just integers, and so `--ratio 100.5` will change the ratio by either `100` or `101` pixels. If you don't want this behaviour, I can change it, but it seemed simpler this way.