### PR TITLE
cast terminating NULL to (char *) in execl() call

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -35,7 +35,7 @@ void run_config(void)
 			close(xcb_get_file_descriptor(dpy));
 		}
 		setsid();
-		execl(config_path, config_path, NULL);
+		execl(config_path, config_path, (char *) NULL);
 		err("Couldn't execute the configuration file.\n");
 	}
 }


### PR DESCRIPTION
Just randomly happened upon this, but the Linux Programmer's Manual states:
```
$ man 3 execl

The const char *arg and subsequent ellipses in the 
execl(), execlp(), and execle() functions can be 
thought of as arg0, arg1, ..., argn. <snip> The list of 
arguments must be terminated by a null pointer, 
and, since these are variadic functions, **this pointer
must be cast (char *) NULL**.
```