### PR TITLE
Fix memory leak when lauching bspwm while another WM is already running.

### DIFF
--- a/src/bspwm.c
+++ b/src/bspwm.c
@@ -338,8 +338,7 @@ void register_events(void)
 	xcb_generic_error_t *e = xcb_request_check(dpy, xcb_change_window_attributes_checked(dpy, root, XCB_CW_EVENT_MASK, values));
 	if (e != NULL) {
 		xcb_disconnect(dpy);
-		free(ewmh->screens);
-		free(ewmh->_NET_WM_CM_Sn);
+		xcb_ewmh_connection_wipe(ewmh);
 		free(ewmh);
 		free(e);
 		err("Another window manager is already running.\n");

--- a/src/bspwm.c
+++ b/src/bspwm.c
@@ -338,6 +338,10 @@ void register_events(void)
 	xcb_generic_error_t *e = xcb_request_check(dpy, xcb_change_window_attributes_checked(dpy, root, XCB_CW_EVENT_MASK, values));
 	if (e != NULL) {
 		xcb_disconnect(dpy);
+		free(ewmh->screens);
+		free(ewmh->_NET_WM_CM_Sn);
+		free(ewmh);
+		free(e);
 		err("Another window manager is already running.\n");
 	}
 }


### PR DESCRIPTION
When bspwm is started while another WM is running a leaks of ~400 bytes occurs. Below is the result of an analysis with valgrind : 

==18286== Memcheck, a memory error detector                                                                                                                                                                                                    
==18286== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.                                                                                                                                                                      
==18286== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info                                                                                                                                                                   
==18286== Command: ./bspwm                                                                                                                                                                                                                     
==18286==                                                                                                                                                                                                                                      
Another window manager is already running.                                                                                                                                                                                                     
==18286==                                                                                                                                                                                                                                      
==18286== HEAP SUMMARY:                                                                                                                                                                                                                        
==18286==     in use at exit: 408 bytes in 4 blocks                                                                                                                                                                                            
==18286==   total heap usage: 392 allocs, 388 frees, 63,116 bytes allocated                                                                                                                                                                    
==18286==                                                                                                                                                                                                                                      
==18286== 4 bytes in 1 blocks are still reachable in loss record 1 of 4                                                                                                                                                                        
==18286==    at 0x4C2AF1F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)                                                                                                                                                     
==18286==    by 0x59867A0: xcb_ewmh_init_atoms (in /usr/lib/libxcb-ewmh.so.2.0.0)                                                                                                                                                              
==18286==    by 0x424934: ewmh_init (in /home/jbouron/Documents/Code/bspwm/bspwm)                                                                                                                                                              
==18286==    by 0x404715: setup (in /home/jbouron/Documents/Code/bspwm/bspwm)                                                                                                                                                                  
==18286==    by 0x403FE6: main (in /home/jbouron/Documents/Code/bspwm/bspwm)                                                                                                                                                                   
==18286==                                                                                                                                                                                                                                      
==18286== 8 bytes in 1 blocks are still reachable in loss record 2 of 4                                                                                                                                                                        
==18286==    at 0x4C2AF1F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)                                                                                                                                                     
==18286==    by 0x598678C: xcb_ewmh_init_atoms (in /usr/lib/libxcb-ewmh.so.2.0.0)                                                                                                                                                              
==18286==    by 0x424934: ewmh_init (in /home/jbouron/Documents/Code/bspwm/bspwm)                                                                                                                                                              
==18286==    by 0x404715: setup (in /home/jbouron/Documents/Code/bspwm/bspwm)                                                                                                                                                                  
==18286==    by 0x403FE6: main (in /home/jbouron/Documents/Code/bspwm/bspwm)                                                                                                                                                                   
==18286==                                                                                                                                                                                                                                      
==18286== 36 bytes in 1 blocks are still reachable in loss record 3 of 4                                                                                                                                                                       
==18286==    at 0x4C2AF1F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)                                                                                                                                                     
==18286==    by 0x5158E52: ??? (in /usr/lib/libxcb.so.1.1.0)                                                                                                                                                                                   
==18286==    by 0x5156BDB: ??? (in /usr/lib/libxcb.so.1.1.0)
==18286==    by 0x515839E: ??? (in /usr/lib/libxcb.so.1.1.0)
==18286==    by 0x51585CE: xcb_request_check (in /usr/lib/libxcb.so.1.1.0)
==18286==    by 0x404DD8: register_events (in /home/jbouron/Documents/Code/bspwm/bspwm)
==18286==    by 0x404767: setup (in /home/jbouron/Documents/Code/bspwm/bspwm)
==18286==    by 0x403FE6: main (in /home/jbouron/Documents/Code/bspwm/bspwm)
==18286==
==18286== 360 bytes in 1 blocks are still reachable in loss record 4 of 4
==18286==    at 0x4C2CF35: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==18286==    by 0x424914: ewmh_init (in /home/jbouron/Documents/Code/bspwm/bspwm)
==18286==    by 0x404715: setup (in /home/jbouron/Documents/Code/bspwm/bspwm)
==18286==    by 0x403FE6: main (in /home/jbouron/Documents/Code/bspwm/bspwm)
==18286==
==18286== LEAK SUMMARY:
==18286==    definitely lost: 0 bytes in 0 blocks
==18286==    indirectly lost: 0 bytes in 0 blocks
==18286==      possibly lost: 0 bytes in 0 blocks
==18286==    still reachable: 408 bytes in 4 blocks
==18286==         suppressed: 0 bytes in 0 blocks
==18286==
==18286== For counts of detected and suppressed errors, rerun with: -v
==18286== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

A few free were missing, this simple fix resolved the leaks.