### PR TITLE
Remove deprecated "Encoding" key

### DIFF
--- a/contrib/freedesktop/bspwm.desktop
+++ b/contrib/freedesktop/bspwm.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=bspwm
 Comment=Binary space partitioning window manager
 Exec=bspwm


### PR DESCRIPTION
The "Encoding" key has been deprecated: https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#deprecated-items