### PR TITLE
click_to_focus should also apply to middle and right click

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -340,26 +340,22 @@ void button_press(xcb_generic_event_t *evt)
 {
 	xcb_button_press_event_t *e = (xcb_button_press_event_t *) evt;
 	bool replay = false;
-	switch (e->detail) {
-		case XCB_BUTTON_INDEX_1:
-			if (click_to_focus && cleaned_mask(e->state) == XCB_NONE) {
-				bool pff = pointer_follows_focus;
-				bool pfm = pointer_follows_monitor;
-				pointer_follows_focus = false;
-				pointer_follows_monitor = false;
-				replay = !grab_pointer(ACTION_FOCUS) || !swallow_first_click;
-				pointer_follows_focus = pff;
-				pointer_follows_monitor = pfm;
-			} else {
-				grab_pointer(pointer_actions[0]);
-			}
-			break;
-		case XCB_BUTTON_INDEX_2:
-			grab_pointer(pointer_actions[1]);
-			break;
-		case XCB_BUTTON_INDEX_3:
-			grab_pointer(pointer_actions[2]);
-			break;
+	uint8_t buttons[] = {XCB_BUTTON_INDEX_1, XCB_BUTTON_INDEX_2, XCB_BUTTON_INDEX_3};
+	for (unsigned int i = 0; i < LENGTH(buttons); i++) {
+		if (e->detail != buttons[i]) {
+			continue;
+		}
+		if (click_to_focus && cleaned_mask(e->state) == XCB_NONE) {
+			bool pff = pointer_follows_focus;
+			bool pfm = pointer_follows_monitor;
+			pointer_follows_focus = false;
+			pointer_follows_monitor = false;
+			replay = !grab_pointer(ACTION_FOCUS) || !swallow_first_click;
+			pointer_follows_focus = pff;
+			pointer_follows_monitor = pfm;
+		} else {
+			grab_pointer(pointer_actions[i]);
+		}
 	}
 	xcb_allow_events(dpy, replay ? XCB_ALLOW_REPLAY_POINTER : XCB_ALLOW_SYNC_POINTER, e->time);
 	xcb_flush(dpy);

--- a/src/pointer.c
+++ b/src/pointer.c
@@ -50,11 +50,11 @@ void pointer_init(void)
 
 void window_grab_buttons(xcb_window_t win)
 {
-	if (click_to_focus) {
-		window_grab_button(win, XCB_BUTTON_INDEX_1, XCB_NONE);
-	}
 	uint8_t buttons[] = {XCB_BUTTON_INDEX_1, XCB_BUTTON_INDEX_2, XCB_BUTTON_INDEX_3};
 	for (unsigned int i = 0; i < LENGTH(buttons); i++) {
+		if (click_to_focus) {
+			window_grab_button(win, buttons[i], XCB_NONE);
+		}
 		if (pointer_actions[i] != ACTION_NONE) {
 			window_grab_button(win, buttons[i], pointer_modifier);
 		}


### PR DESCRIPTION
The middle and right mouse click should also be considered a click for the click_to_focus option. Some applications will misbehave when an option is selected through the context menu and multiple windows are open. An example of misbehavior is selecting find in the context menu of the Sublime Text file tree, then the search bar will not be shown in the window with the file tree, but in the Sublime Text window that was focused at the time. And examples of middle click would be pasting in a terminal or opening a link in a new tab in a browser, in both cases I would expect the clicked window to become focused if it was not already. I have been using this patch for a week without any problem.