### PR TITLE
click_to_focus setting should support different preferences

### DIFF
--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -651,7 +651,7 @@ Global Settings
 	Action performed when pressing 'pointer_modifier' + 'button<n>'. Accept the following values: *move*, *resize_side*, *resize_corner*, *focus*, *none*.
 
 'click_to_focus'::
-	Focus a window (or a monitor) by clicking it.
+	Focus a window (or a monitor) by clicking it with the specified mouse buttons. A combination of the following values is accepted, seperated by commas: *button1*, *button2*, *button3*. For example: *button1*,*button3*.
 
 'swallow_first_click'::
 	Don't replay the click that makes a window focused when 'click_to_focus' is set.

--- a/src/events.c
+++ b/src/events.c
@@ -345,7 +345,7 @@ void button_press(xcb_generic_event_t *evt)
 		if (e->detail != buttons[i]) {
 			continue;
 		}
-		if (click_to_focus && cleaned_mask(e->state) == XCB_NONE) {
+		if ((click_to_focus & 1 << i) && cleaned_mask(e->state) == XCB_NONE) {
 			bool pff = pointer_follows_focus;
 			bool pfm = pointer_follows_monitor;
 			pointer_follows_focus = false;

--- a/src/messages.c
+++ b/src/messages.c
@@ -1487,7 +1487,7 @@ void set_setting(coordinates_t loc, char *name, char *value, FILE *rsp)
 			return;
 		}
 	} else if (streq("click_to_focus", name)) {
-		if (parse_bool(value, &click_to_focus)) {
+		if (parse_focus_buttons(value, &click_to_focus)) {
 			ungrab_buttons();
 			grab_buttons();
 		} else {
@@ -1628,6 +1628,8 @@ void get_setting(coordinates_t loc, char *name, FILE* rsp)
 	           streq("pointer_action3", name)) {
 		int index = name[14] - '1';
 		print_pointer_action(pointer_actions[index], rsp);
+	} else if (streq("click_to_focus", name)) {
+		print_focus_buttons(click_to_focus, rsp);
 #define GET_COLOR(s) \
 	} else if (streq(#s, name)) { \
 		fprintf(rsp, "%s", s);
@@ -1643,7 +1645,6 @@ void get_setting(coordinates_t loc, char *name, FILE* rsp)
 	GET_BOOL(gapless_monocle)
 	GET_BOOL(paddingless_monocle)
 	GET_BOOL(single_monocle)
-	GET_BOOL(click_to_focus)
 	GET_BOOL(swallow_first_click)
 	GET_BOOL(focus_follows_pointer)
 	GET_BOOL(pointer_follows_focus)

--- a/src/parse.c
+++ b/src/parse.c
@@ -213,6 +213,31 @@ bool parse_modifier_mask(char *s, uint16_t *m)
 	return false;
 }
 
+bool parse_focus_buttons(char *s, uint8_t *b)
+{
+	char *button = strtok(s, COM_TOK);
+	*b = 0;
+	while (button != NULL) {
+		if (streq("button1", button)) {
+			if (!(*b & 1)) {
+				*b += 1;
+			}
+		} else if (streq("button2", button)) {
+			if (!(*b & 2)) {
+				*b += 2;
+			}
+		} else if (streq("button3", button)) {
+			if (!(*b & 4)) {
+				*b += 4;
+			}
+		} else {
+			return false;
+		}
+		button = strtok(NULL, COM_TOK);
+	}
+	return true;
+}
+
 bool parse_pointer_action(char *s, pointer_action_t *a)
 {
 	if (streq("move", s)) {

--- a/src/parse.h
+++ b/src/parse.h
@@ -8,6 +8,7 @@
 #define CAT_CHR  '.'
 #define EQL_TOK  "="
 #define COL_TOK  ":"
+#define COM_TOK  ","
 
 bool parse_bool(char *value, bool *b);
 bool parse_split_type(char *s, split_type_t *t);
@@ -22,6 +23,7 @@ bool parse_history_direction(char *s, history_dir_t *d);
 bool parse_flip(char *s, flip_t *f);
 bool parse_resize_handle(char *s, resize_handle_t *h);
 bool parse_modifier_mask(char *s, uint16_t *m);
+bool parse_focus_buttons(char *s, uint8_t *b);
 bool parse_pointer_action(char *s, pointer_action_t *a);
 bool parse_child_polarity(char *s, child_polarity_t *p);
 bool parse_tightness(char *s, tightness_t *t);

--- a/src/pointer.c
+++ b/src/pointer.c
@@ -52,7 +52,7 @@ void window_grab_buttons(xcb_window_t win)
 {
 	uint8_t buttons[] = {XCB_BUTTON_INDEX_1, XCB_BUTTON_INDEX_2, XCB_BUTTON_INDEX_3};
 	for (unsigned int i = 0; i < LENGTH(buttons); i++) {
-		if (click_to_focus) {
+		if (click_to_focus & 1 << i) {
 			window_grab_button(win, buttons[i], XCB_NONE);
 		}
 		if (pointer_actions[i] != ACTION_NONE) {

--- a/src/query.c
+++ b/src/query.c
@@ -340,6 +340,27 @@ void print_modifier_mask(uint16_t m, FILE *rsp)
 	}
 }
 
+void print_focus_buttons(uint8_t b, FILE *rsp)
+{
+	if (b & 1) {
+		fprintf(rsp, "button1");
+		b--;
+		if (b > 0) {
+			fprintf(rsp, ",");
+		}
+	}
+	if (b & 2) {
+		fprintf(rsp, "button2");
+		b -= 2;
+		if (b > 0) {
+			fprintf(rsp, ",");
+		}
+	}
+	if (b & 4) {
+		fprintf(rsp, "button3");
+	}
+}
+
 void print_pointer_action(pointer_action_t a, FILE *rsp)
 {
 	switch (a) {

--- a/src/query.h
+++ b/src/query.h
@@ -65,6 +65,7 @@ void fprint_monitor_name(monitor_t *m, FILE *rsp);
 void fprint_desktop_id(desktop_t *d, FILE *rsp);
 void fprint_desktop_name(desktop_t *d, FILE *rsp);
 void print_modifier_mask(uint16_t m, FILE *rsp);
+void print_focus_buttons(uint8_t b, FILE *rsp);
 void print_pointer_action(pointer_action_t a, FILE *rsp);
 node_select_t make_node_select(void);
 desktop_select_t make_desktop_select(void);

--- a/src/settings.c
+++ b/src/settings.c
@@ -59,6 +59,7 @@ void load_settings(void)
 	initial_polarity = FIRST_CHILD;
 	directional_focus_tightness = TIGHTNESS_HIGH;
 	pointer_modifier = POINTER_MODIFIER;
+	click_to_focus = CLICK_TO_FOCUS;
 	pointer_motion_interval = POINTER_MOTION_INTERVAL;
 
 	pointer_actions[0] = ACTION_MOVE;
@@ -74,7 +75,6 @@ void load_settings(void)
 	pointer_follows_monitor = POINTER_FOLLOWS_MONITOR;
 	ignore_ewmh_focus = IGNORE_EWMH_FOCUS;
 	center_pseudo_tiled = CENTER_PSEUDO_TILED;
-	click_to_focus = CLICK_TO_FOCUS;
 	swallow_first_click = SWALLOW_FIRST_CLICK;
 	honor_size_hints = HONOR_SIZE_HINTS;
 	remove_disabled_monitors = REMOVE_DISABLED_MONITORS;

--- a/src/settings.h
+++ b/src/settings.h
@@ -31,6 +31,7 @@
 #define CONFIG_NAME              WM_NAME "rc"
 #define CONFIG_HOME_ENV          "XDG_CONFIG_HOME"
 #define POINTER_MODIFIER         XCB_MOD_MASK_4
+#define CLICK_TO_FOCUS           0
 #define POINTER_MOTION_INTERVAL  17
 #define EXTERNAL_RULES_COMMAND   ""
 #define STATUS_PREFIX            "W"
@@ -54,7 +55,6 @@
 #define POINTER_FOLLOWS_MONITOR     false
 #define IGNORE_EWMH_FOCUS           false
 #define CENTER_PSEUDO_TILED         true
-#define CLICK_TO_FOCUS              false
 #define SWALLOW_FIRST_CLICK         false
 #define HONOR_SIZE_HINTS            false
 #define REMOVE_DISABLED_MONITORS    false
@@ -77,6 +77,7 @@ double split_ratio;
 child_polarity_t initial_polarity;
 tightness_t directional_focus_tightness;
 uint16_t pointer_modifier;
+uint8_t click_to_focus;
 uint32_t pointer_motion_interval;
 pointer_action_t pointer_actions[3];
 
@@ -89,7 +90,6 @@ bool pointer_follows_focus;
 bool pointer_follows_monitor;
 bool ignore_ewmh_focus;
 bool center_pseudo_tiled;
-bool click_to_focus;
 bool swallow_first_click;
 bool honor_size_hints;
 bool remove_disabled_monitors;


### PR DESCRIPTION
My previous pull request #674 fixed what for me what buggy behavior caused by having the right click button not focusing the window, but for others such as @Alkeryn this was considered a feature, so to support different preferences I have changed the click_to_focus from being a boolean to a byte that represents which mouse buttons should focus on click. I have tried setting and getting different values and it seems to work correct, but I have not been using it for long as I did with my previous pull request. The default is:

    bspc config click_to_focus ''

Which means no mouse buttons focus on click. And I have:

    bspc config click_to_focus button1,button2,button3

And @Alkeryn could use:

    bspc config click_to_focus button1
