### PR TITLE
Fix GCC warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERCMD  ?= git describe 2> /dev/null
 VERSION := $(shell $(VERCMD) || cat VERSION)
 
-CPPFLAGS += -D_POSIX_C_SOURCE=200112L -DVERSION=\"$(VERSION)\"
+CPPFLAGS += -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\"
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra
 LDLIBS    = -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh -lxcb-randr -lxcb-xinerama
 

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -121,6 +121,7 @@ char *copy_string(char *str, size_t len)
 
 char *mktempfifo(const char *template)
 {
+	int tempfd;
 	char *runtime_dir = getenv(RUNTIME_DIR_ENV);
 	if (runtime_dir == NULL) {
 		runtime_dir = "/tmp";
@@ -133,10 +134,13 @@ char *mktempfifo(const char *template)
 
 	sprintf(fifo_path, "%s/%s", runtime_dir, template);
 
-	if (mktemp(fifo_path) == NULL) {
+	if ((tempfd = mkstemp(fifo_path)) == -1) {
 		free(fifo_path);
 		return NULL;
 	}
+
+	close(tempfd);
+	unlink(fifo_path);
 
 	if (mkfifo(fifo_path, 0666) == -1) {
 		free(fifo_path);

--- a/src/messages.c
+++ b/src/messages.c
@@ -1053,7 +1053,7 @@ void cmd_query(char **args, int num, FILE *rsp)
 		goto end;
 	}
 
-	if (!print_ids && (dom == DOMAIN_NODE | dom == DOMAIN_TREE)) {
+	if (!print_ids && (dom == DOMAIN_NODE || dom == DOMAIN_TREE)) {
 		fail(rsp, "query -%c: --names only applies to -M and -D.\n", dom == DOMAIN_NODE ? 'N' : 'T');
 		goto end;
 	}

--- a/src/subscribe.h
+++ b/src/subscribe.h
@@ -25,7 +25,7 @@
 #ifndef BSPWM_SUBSCRIBE_H
 #define BSPWM_SUBSCRIBE_H
 
-#define FIFO_TEMPLATE  "bspwm_fifo.XXXXX"
+#define FIFO_TEMPLATE  "bspwm_fifo.XXXXXX"
 
 typedef enum {
 	SBSC_MASK_REPORT = 1 << 0,


### PR DESCRIPTION
```
warning: the use of `mktemp' is dangerous, better use `mkstemp' or `mkdtemp'
warning: implicit declaration of function ‘mktemp’ [-Wimplicit-function-declaration]

src/messages.c:1056:25: warning: suggest parentheses around comparison in operand of ‘|’ [-Wparentheses]
  if (!print_ids && (dom == DOMAIN_NODE | dom == DOMAIN_TREE))
                         ^
```
The value of `D_POSIX_C_SOURCE` had to be increased :(

I also fixed the fifo template in this patch.
From `man mktemp`:
> The last **six** characters of template must be XXXXXX and these are replaced with a string that makes the filename unique.