### PR TITLE
Allow passing LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ VERSION := $(shell $(VERCMD) || cat VERSION)
 
 CPPFLAGS += -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\"
 CFLAGS   += -std=c99 -pedantic -Wall -Wextra
-LDLIBS    = -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh -lxcb-randr -lxcb-xinerama
+LDFLAGS  ?=
+LDLIBS    = $(LDFLAGS) -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh -lxcb-randr -lxcb-xinerama
 
 PREFIX    ?= /usr/local
 BINPREFIX ?= $(PREFIX)/bin


### PR DESCRIPTION
[This is required](http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/x11/bspwm/Makefile?rev=HEAD&content-type=text/x-cvsweb-markup) for (at least) OpenBSD where we need to pass `-L/usr/X11R6/lib` to the linker.