### PR TITLE
Attempt to keep pseudo-tiled windows from overflowing the screen

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -120,8 +120,8 @@ void apply_layout(monitor_t *m, desktop_t *d, node_t *n, layout_t l, xcb_rectang
 					r.x = rect.x - bw + (rect.width - wg - r.width) / 2;
 					r.y = rect.y - bw + (rect.height - wg - r.height) / 2;
 					// try and keep window from overflowing root_rect
-					r.x += -MIN(r.x - root_rect.x, 0) - MAX((int)(r.x + r.width + 2*bw) - (root_rect.x + root_rect.width), 0);
-					r.y += -MIN(r.y - root_rect.y, 0) - MAX((int)(r.y + r.height + 2*bw) - (root_rect.y + root_rect.height), 0);
+					r.x += -MIN(r.x - root_rect.x + wg, 0) - MAX((int)(r.x + r.width + 2*bw) - (root_rect.x + root_rect.width), 0);
+					r.y += -MIN(r.y - root_rect.y + wg, 0) - MAX((int)(r.y + r.height + 2*bw) - (root_rect.y + root_rect.height), 0);
 				} else {
 					r.x = rect.x;
 					r.y = rect.y;

--- a/src/tree.c
+++ b/src/tree.c
@@ -119,6 +119,9 @@ void apply_layout(monitor_t *m, desktop_t *d, node_t *n, layout_t l, xcb_rectang
 				if (center_pseudo_tiled) {
 					r.x = rect.x - bw + (rect.width - wg - r.width) / 2;
 					r.y = rect.y - bw + (rect.height - wg - r.height) / 2;
+					// try and keep window from overflowing root_rect
+					r.x += -MIN(r.x - root_rect.x, 0) - MAX((int)(r.x + r.width + 2*bw) - (root_rect.x + root_rect.width), 0);
+					r.y += -MIN(r.y - root_rect.y, 0) - MAX((int)(r.y + r.height + 2*bw) - (root_rect.y + root_rect.height), 0);
 				} else {
 					r.x = rect.x;
 					r.y = rect.y;


### PR DESCRIPTION
Move centered pseudo-tiled windows around to keep them within the bounds of the
root_rect as much as possible.  If the size of the pseudo-tiled window
exceeds that of root_rect in a given direction, then we let it overflow.

When pseudo-tiled windows are pushed off the screen there's no easy way to view the cut off part. This change simply prevents such windows from ending up partly off-screen (if there is room).