### PR TITLE
Reflect single_monocle layout in report. Fixes #730.

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -137,6 +137,9 @@ bool find_any_desktop(coordinates_t *ref, coordinates_t *dst, desktop_select_t *
 
 bool set_layout(monitor_t *m, desktop_t *d, layout_t l)
 {
+	layout_t actual_layout = IS_SINGLE_MONOCLE(d) ? LAYOUT_MONOCLE : l;
+	bool actual_layout_changed = (d->layout != actual_layout);
+
 	if (d->layout == l) {
 		return false;
 	}
@@ -145,9 +148,13 @@ bool set_layout(monitor_t *m, desktop_t *d, layout_t l)
 
 	handle_presel_feedbacks(m, d);
 
+	if (!actual_layout_changed) {
+		return true;
+	}
+
 	arrange(m, d);
 
-	put_status(SBSC_MASK_DESKTOP_LAYOUT, "desktop_layout 0x%08X 0x%08X %s\n", m->id, d->id, LAYOUT_STR(l));
+	put_status(SBSC_MASK_DESKTOP_LAYOUT, "desktop_layout 0x%08X 0x%08X %s\n", m->id, d->id, LAYOUT_STR(actual_layout));
 
 	if (d == m->desk) {
 		put_status(SBSC_MASK_REPORT);

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -40,7 +40,10 @@
 #define IS_FLOATING(c)    (c->state == STATE_FLOATING)
 #define IS_FULLSCREEN(c)  (c->state == STATE_FULLSCREEN)
 #define IS_RECEPTACLE(n)  (is_leaf(n) && n->client == NULL)
-#define IS_MONOCLE(d)     (d->layout == LAYOUT_MONOCLE || (single_monocle && tiled_count(d->root, true) <= 1))
+
+#define IS_SINGLE_MONOCLE(d) (single_monocle && tiled_count(d->root, true) <= 1)
+#define IS_MONOCLE(d)	  (d->layout == LAYOUT_MONOCLE || IS_SINGLE_MONOCLE(d))
+#define ACTUAL_LAYOUT(d)  (IS_MONOCLE(d) ? LAYOUT_MONOCLE : d->layout)
 
 #define BOOL_STR(A)       ((A) ? "true" : "false")
 #define ON_OFF_STR(A)     ((A) ? "on" : "off")

--- a/src/messages.c
+++ b/src/messages.c
@@ -1669,6 +1669,7 @@ void set_setting(coordinates_t loc, char *name, char *value, FILE *rsp)
 		SET_BOOL(borderless_monocle)
 		SET_BOOL(gapless_monocle)
 		SET_BOOL(single_monocle)
+		put_status(SBSC_MASK_REPORT);
 		SET_BOOL(swallow_first_click)
 		SET_BOOL(pointer_follows_focus)
 		SET_BOOL(pointer_follows_monitor)

--- a/src/subscribe.c
+++ b/src/subscribe.c
@@ -31,6 +31,7 @@
 #include "desktop.h"
 #include "settings.h"
 #include "subscribe.h"
+#include "tree.h"
 
 subscriber_list_t *make_subscriber_list(FILE *stream, char *fifo_path, int field, int count)
 {
@@ -99,7 +100,7 @@ int print_report(FILE *stream)
 			fprintf(stream, ":%c%s", c, d->name);
 		}
 		if (m->desk != NULL) {
-			fprintf(stream, ":L%c", LAYOUT_CHR(m->desk->layout));
+			fprintf(stream, ":L%c", LAYOUT_CHR(ACTUAL_LAYOUT(m->desk)));
 			if (m->desk->focus != NULL) {
 				node_t *n = m->desk->focus;
 				if (n->client != NULL) {

--- a/src/tree.c
+++ b/src/tree.c
@@ -46,11 +46,7 @@ void arrange(monitor_t *m, desktop_t *d)
 		return;
 	}
 
-	layout_t l = d->layout;
-
-	if (single_monocle && tiled_count(d->root, true) <= 1) {
-		l = LAYOUT_MONOCLE;
-	}
+	layout_t l = ACTUAL_LAYOUT(d);
 
 	xcb_rectangle_t rect = m->rectangle;
 
@@ -445,6 +441,8 @@ void insert_receptacle(monitor_t *m, desktop_t *d, node_t *n)
 {
 	node_t *r = make_node(XCB_NONE);
 	insert_node(m, d, r, n);
+
+	put_status(SBSC_MASK_REPORT);
 }
 
 bool activate_node(monitor_t *m, desktop_t *d, node_t *n)


### PR DESCRIPTION
If `single_monocle` option is set, there is only one window on desktop, it will look in report as if the layout is monocle.
Also print a report after inserting a receptacle (it seems like in other places a report is printed already) and after setting `single_monocle` option with `bspc config`.