### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,4 +9,4 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 indent_style = tab
-indent_size = 8
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = tab
+indent_size = 8

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -17,11 +17,14 @@ I follow the [Linux Coding Style][4] with the following variations:
 - [Indent with tabs, align with spaces][5].
 - Always use braces when using control structures.
 
+An [EditorConfig][6] is included for convinience.
+
 [1]: https://www.bell-labs.com/usr/dmr/www/cbook/
 [2]: https://xcb.freedesktop.org/tutorial/
 [3]: http://git-scm.com/documentation
 [4]: https://www.kernel.org/doc/Documentation/process/coding-style.rst
 [5]: http://lea.verou.me/2012/01/why-tabs-are-clearly-superior/
+[6]: https://editorconfig.org
 
 ## Donations
 


### PR DESCRIPTION
A convenience for developers who use the [EditorConfig](https://editorconfig.org) plugin with their code editor.

This will help keep new code format consistent between contributors (i.e. urge tabs instead of spaces, tab space of 8 as noted in the [Linux Kernel Coding Guide](https://www.kernel.org/doc/Documentation/process/coding-style.rst), etc)