### PR TITLE
add rule query to query_tree

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -58,6 +58,9 @@ void query_tree(FILE *rsp)
 	fprintf(rsp,",");
 	fprintf(rsp, "\"stackingList\":");
 	query_stack(rsp);
+	fprintf(rsp,",");
+	fprintf(rsp, "\"rules\":");
+	query_rules(rsp);
 	fprintf(rsp, "}");
 
 }
@@ -215,6 +218,23 @@ void query_stack(FILE *rsp)
 	for (stacking_list_t *s = stack_head; s != NULL; s = s->next) {
 		fprintf(rsp, "%u", s->node->id);
 		if (s->next != NULL) {
+			fprintf(rsp, ",");
+		}
+	}
+	fprintf(rsp, "]");
+}
+
+void query_rules(FILE *rsp)
+{
+	fprintf(rsp, "[");
+	for (rule_t *r = rule_head; r != NULL; r = r->next) {
+		fprintf(rsp, "{");
+		fprintf(rsp, "\"className\":\"%s\",", r->class_name);
+		fprintf(rsp, "\"instance_name\":\"%s\",", r->instance_name);
+		fprintf(rsp, "\"one_shot\":\"%s\",", BOOL_STR(r->one_shot));
+		fprintf(rsp, "\"effect\":\"%s\"", r->effect);
+		fprintf(rsp,"}");
+		if (r->next != NULL) {
 			fprintf(rsp, ",");
 		}
 	}

--- a/src/query.h
+++ b/src/query.h
@@ -56,6 +56,7 @@ void query_padding(padding_t p, FILE *rsp);
 void query_history(FILE *rsp);
 void query_coordinates(coordinates_t *loc, FILE *rsp);
 void query_stack(FILE *rsp);
+void query_rules(FILE *rsp);
 int query_node_ids(coordinates_t *ref, coordinates_t *trg, node_select_t *sel, FILE *rsp);
 int query_node_ids_in(node_t *n, desktop_t *d, monitor_t *m, coordinates_t *ref, coordinates_t *trg, node_select_t *sel, FILE *rsp);
 int query_desktop_ids(coordinates_t *ref, coordinates_t *trg, desktop_select_t *sel, desktop_printer_t printer, FILE *rsp);


### PR DESCRIPTION
Prints out rules at the end of the `query_tree` json.
Relates to #904 

```
...
    "stackingList": [
        91461
    ],
    "rules": [
        {
            "className": "Polybar",
            "instance_name": "*",
            "one_shot": "false",
            "effect": "manage=off"
        },
        {
            "className": "Polybar",
            "instance_name": "*",
            "one_shot": "false",
            "effect": "manage=off state=floating follow=on focus=on"
        }
    ]
}
```