### PR TITLE
Fix desktop_layout event (see #912)

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -135,10 +135,18 @@ bool find_any_desktop(coordinates_t *ref, coordinates_t *dst, desktop_select_t *
 	return false;
 }
 
+void notify_layout(monitor_t *m, desktop_t *d, layout_t l)
+{
+	put_status(SBSC_MASK_DESKTOP_LAYOUT, "desktop_layout 0x%08X 0x%08X %s\n", m->id, d->id, LAYOUT_STR(l));
+
+	if (m == mon && d == m->desk) {
+		put_status(SBSC_MASK_REPORT);
+	}
+}
+
 bool set_layout(monitor_t *m, desktop_t *d, layout_t l)
 {
-	layout_t actual_layout = IS_SINGLE_MONOCLE(d) ? LAYOUT_MONOCLE : l;
-	bool actual_layout_changed = (d->layout != actual_layout);
+	bool is_single_monocle = IS_SINGLE_MONOCLE(d);
 
 	if (d->layout == l) {
 		return false;
@@ -148,16 +156,10 @@ bool set_layout(monitor_t *m, desktop_t *d, layout_t l)
 
 	handle_presel_feedbacks(m, d);
 
-	if (!actual_layout_changed) {
-		return true;
-	}
+	if (!is_single_monocle) {
+		arrange(m, d);
 
-	arrange(m, d);
-
-	put_status(SBSC_MASK_DESKTOP_LAYOUT, "desktop_layout 0x%08X 0x%08X %s\n", m->id, d->id, LAYOUT_STR(actual_layout));
-
-	if (d == m->desk) {
-		put_status(SBSC_MASK_REPORT);
+		notify_layout(m, d, l);
 	}
 
 	return true;

--- a/src/desktop.c
+++ b/src/desktop.c
@@ -137,6 +137,9 @@ bool find_any_desktop(coordinates_t *ref, coordinates_t *dst, desktop_select_t *
 
 bool set_layout(monitor_t *m, desktop_t *d, layout_t l)
 {
+	layout_t actual_layout = IS_SINGLE_MONOCLE(d) ? LAYOUT_MONOCLE : l;
+	bool actual_layout_changed = (d->layout != actual_layout);
+
 	if (d->layout == l) {
 		return false;
 	}
@@ -145,9 +148,13 @@ bool set_layout(monitor_t *m, desktop_t *d, layout_t l)
 
 	handle_presel_feedbacks(m, d);
 
+	if (!actual_layout_changed) {
+		return true;
+	}
+
 	arrange(m, d);
 
-	put_status(SBSC_MASK_DESKTOP_LAYOUT, "desktop_layout 0x%08X 0x%08X %s\n", m->id, d->id, LAYOUT_STR(l));
+	put_status(SBSC_MASK_DESKTOP_LAYOUT, "desktop_layout 0x%08X 0x%08X %s\n", m->id, d->id, LAYOUT_STR(actual_layout));
 
 	if (d == m->desk) {
 		put_status(SBSC_MASK_REPORT);

--- a/src/desktop.h
+++ b/src/desktop.h
@@ -31,6 +31,7 @@ void focus_desktop(monitor_t *m, desktop_t *d);
 bool activate_desktop(monitor_t *m, desktop_t *d);
 bool find_closest_desktop(coordinates_t *ref, coordinates_t *dst, cycle_dir_t dir, desktop_select_t *sel);
 bool find_any_desktop(coordinates_t *ref, coordinates_t *dst, desktop_select_t *sel);
+void notify_layout(monitor_t *m, desktop_t *d, layout_t l);
 bool set_layout(monitor_t *m, desktop_t *d, layout_t l);
 void handle_presel_feedbacks(monitor_t *m, desktop_t *d);
 bool transfer_desktop(monitor_t *ms, monitor_t *md, desktop_t *d, bool follow);

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -40,7 +40,10 @@
 #define IS_FLOATING(c)    (c->state == STATE_FLOATING)
 #define IS_FULLSCREEN(c)  (c->state == STATE_FULLSCREEN)
 #define IS_RECEPTACLE(n)  (is_leaf(n) && n->client == NULL)
-#define IS_MONOCLE(d)     (d->layout == LAYOUT_MONOCLE || (single_monocle && tiled_count(d->root, true) <= 1))
+
+#define IS_SINGLE_MONOCLE(d) (single_monocle && tiled_count(d->root, true) <= 1)
+#define IS_MONOCLE(d)	  (d->layout == LAYOUT_MONOCLE || IS_SINGLE_MONOCLE(d))
+#define ACTUAL_LAYOUT(d)  (IS_MONOCLE(d) ? LAYOUT_MONOCLE : d->layout)
 
 #define BOOL_STR(A)       ((A) ? "true" : "false")
 #define ON_OFF_STR(A)     ((A) ? "on" : "off")

--- a/src/messages.c
+++ b/src/messages.c
@@ -1669,6 +1669,7 @@ void set_setting(coordinates_t loc, char *name, char *value, FILE *rsp)
 		SET_BOOL(borderless_monocle)
 		SET_BOOL(gapless_monocle)
 		SET_BOOL(single_monocle)
+		put_status(SBSC_MASK_REPORT);
 		SET_BOOL(swallow_first_click)
 		SET_BOOL(pointer_follows_focus)
 		SET_BOOL(pointer_follows_monitor)

--- a/src/messages.c
+++ b/src/messages.c
@@ -1660,6 +1660,25 @@ void set_setting(coordinates_t loc, char *name, char *value, FILE *rsp)
 			fail(rsp, "config: %s: Invalid value: '%s'.\n", name, value);
 			return;
 		}
+	} else if (streq("single_monocle", name)) { \
+		bool old_single_monocle = single_monocle;
+
+		if (!parse_bool(value, &single_monocle)) {		\
+			fail(rsp, "config: %s: Invalid value: '%s'.\n", name, value); \
+			return; \
+		}
+
+		if (old_single_monocle != single_monocle) {
+			for (monitor_t *m = mon_head; m != NULL; m = m->next) {
+				for (desktop_t *d = m->desk_head; d != NULL; d = d->next) {
+					if (tiled_count(d->root, true) <= 1) {
+						notify_layout(m, d, single_monocle ? LAYOUT_MONOCLE : d->layout);
+					}
+				}
+			}
+			put_status(SBSC_MASK_REPORT);
+		}
+
 #define SET_BOOL(s) \
 	} else if (streq(#s, name)) { \
 		if (!parse_bool(value, &s)) { \
@@ -1668,8 +1687,6 @@ void set_setting(coordinates_t loc, char *name, char *value, FILE *rsp)
 		}
 		SET_BOOL(borderless_monocle)
 		SET_BOOL(gapless_monocle)
-		SET_BOOL(single_monocle)
-		put_status(SBSC_MASK_REPORT);
 		SET_BOOL(swallow_first_click)
 		SET_BOOL(pointer_follows_focus)
 		SET_BOOL(pointer_follows_monitor)

--- a/src/subscribe.c
+++ b/src/subscribe.c
@@ -31,6 +31,7 @@
 #include "desktop.h"
 #include "settings.h"
 #include "subscribe.h"
+#include "tree.h"
 
 subscriber_list_t *make_subscriber_list(FILE *stream, char *fifo_path, int field, int count)
 {
@@ -99,7 +100,7 @@ int print_report(FILE *stream)
 			fprintf(stream, ":%c%s", c, d->name);
 		}
 		if (m->desk != NULL) {
-			fprintf(stream, ":L%c", LAYOUT_CHR(m->desk->layout));
+			fprintf(stream, ":L%c", LAYOUT_CHR(ACTUAL_LAYOUT(m->desk)));
 			if (m->desk->focus != NULL) {
 				node_t *n = m->desk->focus;
 				if (n->client != NULL) {

--- a/src/tree.c
+++ b/src/tree.c
@@ -46,11 +46,7 @@ void arrange(monitor_t *m, desktop_t *d)
 		return;
 	}
 
-	layout_t l = d->layout;
-
-	if (single_monocle && tiled_count(d->root, true) <= 1) {
-		l = LAYOUT_MONOCLE;
-	}
+	layout_t l = ACTUAL_LAYOUT(d);
 
 	xcb_rectangle_t rect = m->rectangle;
 
@@ -445,6 +441,8 @@ void insert_receptacle(monitor_t *m, desktop_t *d, node_t *n)
 {
 	node_t *r = make_node(XCB_NONE);
 	insert_node(m, d, r, n);
+
+	put_status(SBSC_MASK_REPORT);
 }
 
 bool activate_node(monitor_t *m, desktop_t *d, node_t *n)

--- a/src/tree.h
+++ b/src/tree.h
@@ -37,6 +37,7 @@ void presel_ratio(monitor_t *m, desktop_t *d, node_t *n, double ratio);
 void cancel_presel(monitor_t *m, desktop_t *d, node_t *n);
 void cancel_presel_in(monitor_t *m, desktop_t *d, node_t *n);
 node_t *find_public(desktop_t *d);
+node_t *insert_node_notify_layout(monitor_t *m, desktop_t *d, node_t *n, node_t *f);
 node_t *insert_node(monitor_t *m, desktop_t *d, node_t *n, node_t *f);
 void insert_receptacle(monitor_t *m, desktop_t *d, node_t *n);
 bool activate_node(monitor_t *m, desktop_t *d, node_t *n);

--- a/src/window.c
+++ b/src/window.c
@@ -163,7 +163,7 @@ bool manage_window(xcb_window_t win, rule_consequence_t *csq, int fd)
 		n->vacant = true;
 	}
 
-	f = insert_node(m, d, n, f);
+	f = insert_node_notify_layout(m, d, n, f);
 	clients_count++;
 
 	n->vacant = false;


### PR DESCRIPTION
Commit 32ff624 broke `desktop_layout` events and made them not consistent with reports; sorry for that.

I added a commit that fixes this. Couldn't find a way to reopen #912 so making it another PR.