### PR TITLE
added 'marked' flag to report documentation

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -1582,7 +1582,7 @@ Layout of the focused desktop of a monitor\&.
 State of the focused node of a focused desktop\&.
 .RE
 .PP
-\fIG(S?P?L?)\fR
+\fIG(S?P?L?M?)\fR
 .RS 4
 Active flags of the focused node of a focused desktop\&.
 .RE

--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -932,7 +932,7 @@ Each item has the form '<type><value>' where '<type>' is the first character of 
 'T(T|P|F|=|@)'::
 	State of the focused node of a focused desktop.
 
-'G(S?P?L?)'::
+'G(S?P?L?M?)'::
 	Active flags of the focused node of a focused desktop.
 
 Environment Variables


### PR DESCRIPTION
"marked" flagged nodes being reported as "M" was missing in the manual.