### PR TITLE
Enforce strict mode of jsmn.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERCMD  ?= git describe 2> /dev/null
 VERSION := $(shell $(VERCMD) || cat VERSION)
 
 CPPFLAGS += -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\"
-CFLAGS   += -std=c99 -pedantic -Wall -Wextra
+CFLAGS   += -std=c99 -pedantic -Wall -Wextra -DJSMN_STRICT
 LDFLAGS  ?=
 LDLIBS    = $(LDFLAGS) -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh -lxcb-randr -lxcb-xinerama -lxcb-shape
 


### PR DESCRIPTION
If no strict mode of jsmn is enforced, then the correct amount of
json elements would have to be checked to avoid segmentation faults
on malformed state files:

$ echo '{ "focusedMonitorId" }' > malformed-state
$ bspwm -s malformed-state
Segmentation fault
$ _

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>