### PR TITLE
Select modifier for split type and descriptor

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -100,7 +100,7 @@ Select a node\&.
 .RS 4
 .\}
 .nf
-NODE_SEL := [NODE_SEL#](DIR|CYCLE_DIR|PATH|any|last|newest|
+NODE_SEL := [NODE_SEL#](DIR|CYCLE_DIR|PATH|any|parents|last|newest|
                         older|newer|focused|pointed|biggest|smallest|
                         <node_id>)[\&.[!]focused][\&.[!]active][\&.[!]automatic][\&.[!]local]
                                   [\&.[!]leaf][\&.[!]window][\&.[!]STATE][\&.[!]FLAG][\&.[!]LAYER]
@@ -146,6 +146,11 @@ Selects the node at the given path\&.
 any
 .RS 4
 Selects the first node that matches the given selectors\&.
+.RE
+.PP
+parents
+.RS 4
+Selects the first descendant of the reference node that matches the given selectors\&.
 .RE
 .PP
 last
@@ -267,6 +272,16 @@ Only consider nodes in the reference desktop\&.
 [!]leaf
 .RS 4
 Only consider leaf nodes\&.
+.RE
+.PP
+[!]horizontal
+.RS 4
+Only consider nodes whose split type is horizontal\&.
+.RE
+.PP
+[!]vertical
+.RS 4
+Only consider nodes whose split type is vertical\&.
 .RE
 .PP
 [!]window

--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -74,7 +74,7 @@ Node
 Select a node.
 
 ----
-NODE_SEL := [NODE_SEL#](DIR|CYCLE_DIR|PATH|any|last|newest|
+NODE_SEL := [NODE_SEL#](DIR|CYCLE_DIR|PATH|any|parent|last|newest|
                         older|newer|focused|pointed|biggest|smallest|
                         <node_id>)[.[!]focused][.[!]active][.[!]automatic][.[!]local]
                                   [.[!]leaf][.[!]window][.[!]STATE][.[!]FLAG][.[!]LAYER]
@@ -105,6 +105,9 @@ Descriptors
 
 any::
 	Selects the first node that matches the given selectors.
+
+parents::
+	Selects the first descendant of the reference node that matches the given selectors.
 
 last::
 	Selects the previously focused node relative to the reference node.
@@ -170,6 +173,12 @@ Modifiers
 
 [!]leaf::
 	Only consider leaf nodes.
+
+[!]horizontal::
+	Only consider nodes whose split type is horizontal.
+
+[!]vertical::
+	Only consider nodes whose split type is vertical.
 
 [!]window::
 	Only consider nodes that hold a window.

--- a/examples/resizing/bspc_resize
+++ b/examples/resizing/bspc_resize
@@ -1,0 +1,38 @@
+#!/bin/sh
+# NOTE: This script depends on 'jq' for parsing json!
+# make this script executable and put it somewhere in your PATH
+if [[ "$1" =~ "^(left|down|up|right)$" ]] ; then
+	echo "invalid option"
+	exit 1
+fi
+if [[ $(bspc query -T -n | jq -r '.client.state') == "floating" ]] ; then
+	case "$1" in
+	"left")
+		bspc node -z right -20 0
+		;;
+	"down")
+		bspc node -z bottom 0 +20
+		;;
+	"up")
+		bspc node -z bottom 0 -20
+		;;
+	"right")
+		bspc node -z right +20 0
+		;;
+	esac
+else
+	case "$1" in
+	"left")
+		bspc node 'parents.!leaf.vertical' -r -0.05
+		;;
+	"down")
+		bspc node 'parents.!leaf.horizontal' -r +0.05
+		;;
+	"up")
+		bspc node 'parents.!leaf.horizontal' -r -0.05
+		;;
+	"right")
+		bspc node 'parents.!leaf.vertical' -r +0.05
+		;;
+	esac
+fi

--- a/examples/resizing/sxhkdrc
+++ b/examples/resizing/sxhkdrc
@@ -1,0 +1,11 @@
+#
+# move/resize/rotate
+#
+
+# easy resizing with bspc_resize script
+super + alt + {h,j,k,l}
+	bspc_resize {left,down,up,right}
+
+# move upper left corner
+super + alt + shift + {h,j,k,l}
+	bspc node -z {left -20 0,top 0 +20,top 0 -20,left +20 0}

--- a/src/parse.c
+++ b/src/parse.c
@@ -542,6 +542,8 @@ bool parse_node_modifiers(char *desc, node_select_t *sel)
 		GET_MOD(below)
 		GET_MOD(normal)
 		GET_MOD(above)
+		GET_MOD(horizontal)
+		GET_MOD(vertical)
 		} else {
 			return false;
 		}

--- a/src/query.c
+++ b/src/query.c
@@ -470,7 +470,9 @@ node_select_t make_node_select(void)
 		.ancestor_of = OPTION_NONE,
 		.below = OPTION_NONE,
 		.normal = OPTION_NONE,
-		.above = OPTION_NONE
+		.above = OPTION_NONE,
+		.horizontal = OPTION_NONE,
+		.vertical = OPTION_NONE
 	};
 	return sel;
 }
@@ -549,6 +551,8 @@ int node_from_desc(char *desc, coordinates_t *ref, coordinates_t *dst)
 		history_find_node(hdi, ref, dst, &sel);
 	} else if (streq("any", desc)) {
 		find_any_node(ref, dst, &sel);
+	} else if (streq("parents", desc)) {
+		find_first_parent_node(ref, dst, &sel);
 	} else if (streq("last", desc)) {
 		history_find_node(HISTORY_OLDER, ref, dst, &sel);
 	} else if (streq("newest", desc)) {
@@ -1137,6 +1141,20 @@ bool node_matches(coordinates_t *loc, coordinates_t *ref, node_select_t *sel)
 	}
 	WFLAG(urgent)
 #undef WFLAG
+
+	if (sel->horizontal != OPTION_NONE &&
+	    loc->node->split_type != TYPE_HORIZONTAL
+		? sel->horizontal == OPTION_TRUE
+		: sel->horizontal == OPTION_FALSE) {
+		return false;
+	}
+
+	if (sel->vertical != OPTION_NONE &&
+	    loc->node->split_type != TYPE_VERTICAL
+		? sel->vertical == OPTION_TRUE
+		: sel->vertical == OPTION_FALSE) {
+		return false;
+	}
 
 	return true;
 }

--- a/src/tree.c
+++ b/src/tree.c
@@ -1014,6 +1014,17 @@ bool find_any_node_in(monitor_t *m, desktop_t *d, node_t *n, coordinates_t *ref,
 	}
 }
 
+void find_first_parent_node(coordinates_t *ref, coordinates_t *dst, node_select_t *sel)
+{
+	coordinates_t loc = {ref->monitor, ref->desktop, ref->node};
+	while (!node_matches(&loc, ref, sel)) {
+		if ( (loc.node = loc.node->parent) == NULL ) {
+			return;
+		}
+	}
+	*dst = loc;
+}
+
 /* Based on https://github.com/ntrrgc/right-window */
 void find_nearest_neighbor(coordinates_t *ref, coordinates_t *dst, direction_t dir, node_select_t *sel)
 {

--- a/src/tree.h
+++ b/src/tree.h
@@ -68,6 +68,7 @@ bool find_by_id(uint32_t id, coordinates_t *loc);
 node_t *find_by_id_in(node_t *r, uint32_t id);
 void find_any_node(coordinates_t *ref, coordinates_t *dst, node_select_t *sel);
 bool find_any_node_in(monitor_t *m, desktop_t *d, node_t *n, coordinates_t *ref, coordinates_t *dst, node_select_t *sel);
+void find_first_parent_node(coordinates_t *ref, coordinates_t *dst, node_select_t *sel);
 void find_nearest_neighbor(coordinates_t *ref, coordinates_t *dst, direction_t dir, node_select_t *sel);
 unsigned int node_area(desktop_t *d, node_t *n);
 int tiled_count(node_t *n, bool include_receptacles);

--- a/src/types.h
+++ b/src/types.h
@@ -183,6 +183,8 @@ typedef struct {
 	option_bool_t below;
 	option_bool_t normal;
 	option_bool_t above;
+	option_bool_t horizontal;
+	option_bool_t vertical;
 } node_select_t;
 
 typedef struct {


### PR DESCRIPTION
This addresses issue #823
I added two new modifiers for node selection. One testing for horizontal split type and one for vertical split type. I know that this is a little bit redundant because !horizontal is the same as vertical (and vice versa) but i didn't want to choose one and this way it's more user-friendly.
I also added a descriptor for node selection that picks the first descendant of the reference node (i.e it goes up from the reference node until it finds a node that matches the given modifiers).

If you want to know how this is of any help read here #823

It would be nice if someone could look at my function "find_first_parent_node" in tree.c and check if i didn't do anything stupid. I'm not really comfortable with programming in C and all i did was mimicing code that was already there.

I called the new descriptor "parents" but i'm sure there is a better name for this. Maybe "first_descendant" would be more clear, but it is pretty long. Also i'm not sure if the underscore could cause some problems while parsing.
And while we're at it "find_first_parent_node" also isn't really a good name.