### PR TITLE
Add WM_NAME rule matching

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -1041,12 +1041,12 @@ rule \fICOMMANDS\fR
 \fBCommands\fR
 .RS 4
 .PP
-\fB\-a\fR, \fB\-\-add\fR (<class_name>|*)[:(<instance_name>|*)] [\fB\-o\fR|\fB\-\-one\-shot\fR] [monitor=MONITOR_SEL|desktop=DESKTOP_SEL|node=NODE_SEL] [state=STATE] [layer=LAYER] [split_dir=DIR] [split_ratio=RATIO] [(hidden|sticky|private|locked|marked|center|follow|manage|focus|border)=(on|off)] [rectangle=WxH+X+Y]
+\fB\-a\fR, \fB\-\-add\fR (<class_name>|*)[:(<instance_name>|*)][:(<name>|*)] [\fB\-o\fR|\fB\-\-one\-shot\fR] [monitor=MONITOR_SEL|desktop=DESKTOP_SEL|node=NODE_SEL] [state=STATE] [layer=LAYER] [split_dir=DIR] [split_ratio=RATIO] [(hidden|sticky|private|locked|marked|center|follow|manage|focus|border)=(on|off)] [rectangle=WxH+X+Y]
 .RS 4
 Create a new rule\&.
 .RE
 .PP
-\fB\-r\fR, \fB\-\-remove\fR ^<n>|head|tail|(<class_name>|*)[:(<instance_name>|*)]\&...
+\fB\-r\fR, \fB\-\-remove\fR ^<n>|head|tail|(<class_name>|*)[:(<instance_name>|*)][:(<name>|*)]\&...
 .RS 4
 Remove the given rules\&.
 .RE

--- a/src/messages.c
+++ b/src/messages.c
@@ -1138,8 +1138,10 @@ void cmd_rule(char **args, int num, FILE *rsp)
 			rule_t *rule = make_rule();
 			char *class_name = strtok(*args, COL_TOK);
 			char *instance_name = strtok(NULL, COL_TOK);
+			char *name = strtok(NULL, COL_TOK);
 			snprintf(rule->class_name, sizeof(rule->class_name), "%s", class_name);
 			snprintf(rule->instance_name, sizeof(rule->instance_name), "%s", instance_name==NULL?MATCH_ANY:instance_name);
+			snprintf(rule->name, sizeof(rule->name), "%s", name==NULL?MATCH_ANY:name);
 			num--, args++;
 			size_t i = 0;
 			while (num > 0) {

--- a/src/rule.h
+++ b/src/rule.h
@@ -44,6 +44,7 @@ void _apply_window_state(xcb_window_t win, rule_consequence_t *csq);
 void _apply_transient(xcb_window_t win, rule_consequence_t *csq);
 void _apply_hints(xcb_window_t win, rule_consequence_t *csq);
 void _apply_class(xcb_window_t win, rule_consequence_t *csq);
+void _apply_name(xcb_window_t win, rule_consequence_t *csq);
 void parse_keys_values(char *buf, rule_consequence_t *csq);
 void apply_rules(xcb_window_t win, rule_consequence_t *csq);
 bool schedule_rules(xcb_window_t win, rule_consequence_t *csq);

--- a/src/types.h
+++ b/src/types.h
@@ -210,6 +210,7 @@ struct icccm_props_t {
 typedef struct {
 	char class_name[3 * SMALEN / 2];
 	char instance_name[3 * SMALEN / 2];
+	char name[3 * SMALEN / 2];
 	unsigned int border_width;
 	bool urgent;
 	bool shown;
@@ -341,6 +342,7 @@ typedef struct rule_t rule_t;
 struct rule_t {
 	char class_name[MAXLEN];
 	char instance_name[MAXLEN];
+	char name[MAXLEN];
 	char effect[MAXLEN];
 	bool one_shot;
 	rule_t *prev;
@@ -350,6 +352,7 @@ struct rule_t {
 typedef struct {
 	char class_name[3 * SMALEN / 2];
 	char instance_name[3 * SMALEN / 2];
+	char name[3 * SMALEN / 2];
 	char monitor_desc[MAXLEN];
 	char desktop_desc[MAXLEN];
 	char node_desc[MAXLEN];


### PR DESCRIPTION
For my use case I need to be able to add window management rules for processes with unique window names which are only known immediately before the process is started.  This change adds optional window name matching.

The only interface that may not be backwards compatible (that I know of) is the output of `bspc rule -l`