### PR TITLE
Alternative solution to enable building with gcc-10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERCMD  ?= git describe --tags 2> /dev/null
 VERSION := $(shell $(VERCMD) || cat VERSION)
 
 CPPFLAGS += -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\"
-CFLAGS   += -std=c99 -pedantic -Wall -Wextra -DJSMN_STRICT
+CFLAGS   += -std=c99 -pedantic -Wall -Wextra -DJSMN_STRICT -fcommon
 LDFLAGS  ?=
 LDLIBS    = $(LDFLAGS) -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh -lxcb-randr -lxcb-xinerama -lxcb-shape
 


### PR DESCRIPTION
NOTE: this solution is ["discouraged"](https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common).

* Simply enable `-fcommon` without modifying any code. 

Fixes #1119.