### PR TITLE
Yet another solution to allow building with -fno-common

### DIFF
--- a/src/bspwm.c
+++ b/src/bspwm.c
@@ -51,6 +51,44 @@
 #include "query.h"
 #include "bspwm.h"
 
+xcb_connection_t *dpy;
+int default_screen, screen_width, screen_height;
+uint32_t clients_count;
+xcb_screen_t *screen;
+xcb_window_t root;
+char config_path[MAXLEN];
+
+monitor_t *mon;
+monitor_t *mon_head;
+monitor_t *mon_tail;
+monitor_t *pri_mon;
+history_t *history_head;
+history_t *history_tail;
+history_t *history_needle;
+rule_t *rule_head;
+rule_t *rule_tail;
+stacking_list_t *stack_head;
+stacking_list_t *stack_tail;
+subscriber_list_t *subscribe_head;
+subscriber_list_t *subscribe_tail;
+pending_rule_t *pending_rule_head;
+pending_rule_t *pending_rule_tail;
+
+xcb_window_t meta_window;
+motion_recorder_t motion_recorder;
+xcb_atom_t WM_STATE;
+xcb_atom_t WM_TAKE_FOCUS;
+xcb_atom_t WM_DELETE_WINDOW;
+int exit_status;
+
+bool auto_raise;
+bool sticky_still;
+bool hide_sticky;
+bool record_history;
+bool running;
+bool restart;
+bool randr;
+
 int main(int argc, char *argv[])
 {
 	fd_set descriptors;

--- a/src/bspwm.c
+++ b/src/bspwm.c
@@ -483,3 +483,16 @@ void sig_handler(int sig)
 		running = false;
 	}
 }
+
+/* Adapted from i3wm */
+uint32_t get_color_pixel(const char *color)
+{
+	unsigned int red, green, blue;
+	if (sscanf(color + 1, "%02x%02x%02x", &red, &green, &blue) == 3) {
+		/* We set the first 8 bits high to have 100% opacity in case of a 32 bit
+		 * color depth visual. */
+		return (0xFF << 24) | (red << 16 | green << 8 | blue);
+	} else {
+		return screen->black_pixel;
+	}
+}

--- a/src/bspwm.h
+++ b/src/bspwm.h
@@ -92,5 +92,6 @@ void register_events(void);
 void cleanup(void);
 bool check_connection (xcb_connection_t *dpy);
 void sig_handler(int sig);
+uint32_t get_color_pixel(const char *color);
 
 #endif

--- a/src/bspwm.h
+++ b/src/bspwm.h
@@ -44,47 +44,49 @@
 #define MOTION_RECORDER_I   "motion_recorder"
 #define MOTION_RECORDER_IC  MOTION_RECORDER_I "\0" BSPWM_CLASS_NAME
 
-xcb_connection_t *dpy;
-int default_screen, screen_width, screen_height;
-uint32_t clients_count;
-xcb_screen_t *screen;
-xcb_window_t root;
-char config_path[MAXLEN];
-
-monitor_t *mon;
-monitor_t *mon_head;
-monitor_t *mon_tail;
-monitor_t *pri_mon;
-history_t *history_head;
-history_t *history_tail;
-history_t *history_needle;
-rule_t *rule_head;
-rule_t *rule_tail;
-stacking_list_t *stack_head;
-stacking_list_t *stack_tail;
-subscriber_list_t *subscribe_head;
-subscriber_list_t *subscribe_tail;
-pending_rule_t *pending_rule_head;
-pending_rule_t *pending_rule_tail;
-
-xcb_window_t meta_window;
-struct {
+typedef struct {
 	xcb_window_t id;
 	uint16_t sequence;
 	bool enabled;
-} motion_recorder;
-xcb_atom_t WM_STATE;
-xcb_atom_t WM_TAKE_FOCUS;
-xcb_atom_t WM_DELETE_WINDOW;
-int exit_status;
+} motion_recorder_t;
 
-bool auto_raise;
-bool sticky_still;
-bool hide_sticky;
-bool record_history;
-bool running;
-bool restart;
-bool randr;
+extern xcb_connection_t *dpy;
+extern int default_screen, screen_width, screen_height;
+extern uint32_t clients_count;
+extern xcb_screen_t *screen;
+extern xcb_window_t root;
+extern char config_path[MAXLEN];
+
+extern monitor_t *mon;
+extern monitor_t *mon_head;
+extern monitor_t *mon_tail;
+extern monitor_t *pri_mon;
+extern history_t *history_head;
+extern history_t *history_tail;
+extern history_t *history_needle;
+extern rule_t *rule_head;
+extern rule_t *rule_tail;
+extern stacking_list_t *stack_head;
+extern stacking_list_t *stack_tail;
+extern subscriber_list_t *subscribe_head;
+extern subscriber_list_t *subscribe_tail;
+extern pending_rule_t *pending_rule_head;
+extern pending_rule_t *pending_rule_tail;
+
+extern xcb_window_t meta_window;
+extern motion_recorder_t motion_recorder;
+extern xcb_atom_t WM_STATE;
+extern xcb_atom_t WM_TAKE_FOCUS;
+extern xcb_atom_t WM_DELETE_WINDOW;
+extern int exit_status;
+
+extern bool auto_raise;
+extern bool sticky_still;
+extern bool hide_sticky;
+extern bool record_history;
+extern bool running;
+extern bool restart;
+extern bool randr;
 
 void init(void);
 void setup(void);

--- a/src/events.c
+++ b/src/events.c
@@ -35,6 +35,8 @@
 #include "rule.h"
 #include "events.h"
 
+uint8_t randr_base;
+
 void handle_event(xcb_generic_event_t *evt)
 {
 	uint8_t resp_type = XCB_EVENT_RESPONSE_TYPE(evt);

--- a/src/events.h
+++ b/src/events.h
@@ -30,7 +30,7 @@
 
 #define ERROR_CODE_BAD_WINDOW  3
 
-uint8_t randr_base;
+extern uint8_t randr_base;
 static const xcb_button_index_t BUTTONS[] = {XCB_BUTTON_INDEX_1, XCB_BUTTON_INDEX_2, XCB_BUTTON_INDEX_3};
 
 void handle_event(xcb_generic_event_t *evt);

--- a/src/ewmh.c
+++ b/src/ewmh.c
@@ -31,6 +31,8 @@
 #include "tree.h"
 #include "ewmh.h"
 
+xcb_ewmh_connection_t *ewmh;
+
 void ewmh_init(void)
 {
 	ewmh = calloc(1, sizeof(xcb_ewmh_connection_t));

--- a/src/ewmh.h
+++ b/src/ewmh.h
@@ -27,7 +27,7 @@
 
 #include <xcb/xcb_ewmh.h>
 
-xcb_ewmh_connection_t *ewmh;
+extern xcb_ewmh_connection_t *ewmh;
 
 void ewmh_init(void);
 void ewmh_update_active_window(void);

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -181,19 +181,6 @@ int vasprintf(char **buf, const char *fmt, va_list args)
 	return size;
 }
 
-/* Adapted from i3wm */
-uint32_t get_color_pixel(const char *color)
-{
-	unsigned int red, green, blue;
-	if (sscanf(color + 1, "%02x%02x%02x", &red, &green, &blue) == 3) {
-		/* We set the first 8 bits high to have 100% opacity in case of a 32 bit
-		 * color depth visual. */
-		return (0xFF << 24) | (red << 16 | green << 8 | blue);
-	} else {
-		return screen->black_pixel;
-	}
-}
-
 bool is_hex_color(const char *color)
 {
 	if (color[0] != '#' || strlen(color) != 7) {

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -82,7 +82,6 @@ char *copy_string(char *str, size_t len);
 char *mktempfifo(const char *template);
 int asprintf(char **buf, const char *fmt, ...);
 int vasprintf(char **buf, const char *fmt, va_list args);
-uint32_t get_color_pixel(const char *color);
 bool is_hex_color(const char *color);
 
 #endif

--- a/src/pointer.c
+++ b/src/pointer.c
@@ -36,6 +36,13 @@
 #include "window.h"
 #include "pointer.h"
 
+uint16_t num_lock;
+uint16_t caps_lock;
+uint16_t scroll_lock;
+
+bool grabbing;
+node_t *grabbed_node;
+
 void pointer_init(void)
 {
 	num_lock = modfield_from_keysym(XK_Num_Lock);

--- a/src/pointer.h
+++ b/src/pointer.h
@@ -29,12 +29,12 @@
 #define XK_Caps_Lock    0xffe5
 #define XK_Scroll_Lock  0xff14
 
-uint16_t num_lock;
-uint16_t caps_lock;
-uint16_t scroll_lock;
+extern uint16_t num_lock;
+extern uint16_t caps_lock;
+extern uint16_t scroll_lock;
 
-bool grabbing;
-node_t *grabbed_node;
+extern bool grabbing;
+extern node_t *grabbed_node;
 
 void pointer_init(void);
 void window_grab_buttons(xcb_window_t win);

--- a/src/settings.c
+++ b/src/settings.c
@@ -30,6 +30,50 @@
 
 extern char **environ;
 
+char external_rules_command[MAXLEN];
+char status_prefix[MAXLEN];
+
+char normal_border_color[MAXLEN];
+char active_border_color[MAXLEN];
+char focused_border_color[MAXLEN];
+char presel_feedback_color[MAXLEN];
+
+padding_t padding;
+padding_t monocle_padding;
+int window_gap;
+unsigned int border_width;
+double split_ratio;
+child_polarity_t initial_polarity;
+automatic_scheme_t automatic_scheme;
+bool removal_adjustment;
+tightness_t directional_focus_tightness;
+
+uint16_t pointer_modifier;
+uint32_t pointer_motion_interval;
+pointer_action_t pointer_actions[3];
+int8_t mapping_events_count;
+
+bool presel_feedback;
+bool borderless_monocle;
+bool gapless_monocle;
+bool single_monocle;
+
+bool focus_follows_pointer;
+bool pointer_follows_focus;
+bool pointer_follows_monitor;
+int8_t click_to_focus;
+bool swallow_first_click;
+bool ignore_ewmh_focus;
+bool ignore_ewmh_struts;
+state_transition_t ignore_ewmh_fullscreen;
+
+bool center_pseudo_tiled;
+bool honor_size_hints;
+
+bool remove_disabled_monitors;
+bool remove_unplugged_monitors;
+bool merge_overlapping_monitors;
+
 void run_config(void)
 {
 	if (fork() == 0) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -67,49 +67,49 @@
 #define REMOVE_UNPLUGGED_MONITORS   false
 #define MERGE_OVERLAPPING_MONITORS  false
 
-char external_rules_command[MAXLEN];
-char status_prefix[MAXLEN];
+extern char external_rules_command[MAXLEN];
+extern char status_prefix[MAXLEN];
 
-char normal_border_color[MAXLEN];
-char active_border_color[MAXLEN];
-char focused_border_color[MAXLEN];
-char presel_feedback_color[MAXLEN];
+extern char normal_border_color[MAXLEN];
+extern char active_border_color[MAXLEN];
+extern char focused_border_color[MAXLEN];
+extern char presel_feedback_color[MAXLEN];
 
-padding_t padding;
-padding_t monocle_padding;
-int window_gap;
-unsigned int border_width;
-double split_ratio;
-child_polarity_t initial_polarity;
-automatic_scheme_t automatic_scheme;
-bool removal_adjustment;
-tightness_t directional_focus_tightness;
+extern padding_t padding;
+extern padding_t monocle_padding;
+extern int window_gap;
+extern unsigned int border_width;
+extern double split_ratio;
+extern child_polarity_t initial_polarity;
+extern automatic_scheme_t automatic_scheme;
+extern bool removal_adjustment;
+extern tightness_t directional_focus_tightness;
 
-uint16_t pointer_modifier;
-uint32_t pointer_motion_interval;
-pointer_action_t pointer_actions[3];
-int8_t mapping_events_count;
+extern uint16_t pointer_modifier;
+extern uint32_t pointer_motion_interval;
+extern pointer_action_t pointer_actions[3];
+extern int8_t mapping_events_count;
 
-bool presel_feedback;
-bool borderless_monocle;
-bool gapless_monocle;
-bool single_monocle;
+extern bool presel_feedback;
+extern bool borderless_monocle;
+extern bool gapless_monocle;
+extern bool single_monocle;
 
-bool focus_follows_pointer;
-bool pointer_follows_focus;
-bool pointer_follows_monitor;
-int8_t click_to_focus;
-bool swallow_first_click;
-bool ignore_ewmh_focus;
-bool ignore_ewmh_struts;
-state_transition_t ignore_ewmh_fullscreen;
+extern bool focus_follows_pointer;
+extern bool pointer_follows_focus;
+extern bool pointer_follows_monitor;
+extern int8_t click_to_focus;
+extern bool swallow_first_click;
+extern bool ignore_ewmh_focus;
+extern bool ignore_ewmh_struts;
+extern state_transition_t ignore_ewmh_fullscreen;
 
-bool center_pseudo_tiled;
-bool honor_size_hints;
+extern bool center_pseudo_tiled;
+extern bool honor_size_hints;
 
-bool remove_disabled_monitors;
-bool remove_unplugged_monitors;
-bool merge_overlapping_monitors;
+extern bool remove_disabled_monitors;
+extern bool remove_unplugged_monitors;
+extern bool merge_overlapping_monitors;
 
 void run_config(void);
 void load_settings(void);


### PR DESCRIPTION
This solution is more verbose than #1129, but doesn't use #directives.

* `get_color_pixel()` needs to be moved from `helpers.h` to `bspwm.h` (to build `bspc`);
* `motion_recorder_t` is `typedef`-ined for convenience;

Fixes #1119.