### PR TITLE
docs: amend typo in manpage

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -1537,7 +1537,7 @@ The layer of a window changed\&.
 .PP
 \fIpointer_action <monitor_id> <desktop_id> <node_id> move|resize_corner|resize_side begin|end\fR
 .RS 4
-A pointer action occured\&.
+A pointer action occurred\&.
 .RE
 .sp
 Please note that \fBbspwm\fR initializes monitors before it reads messages on its socket, therefore the initial monitor events can\(cqt be received\&.

--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -900,7 +900,7 @@ Events
 	The layer of a window changed.
 
 'pointer_action <monitor_id> <desktop_id> <node_id> move|resize_corner|resize_side begin|end'::
-	A pointer action occured.
+	A pointer action occurred.
 
 Please note that *bspwm* initializes monitors before it reads messages on its socket, therefore the initial monitor events can't be received.
 


### PR DESCRIPTION
Just a typo so I didn't touch the date/source in the header.