### PR TITLE
Check if sxhkd is already running before running it again in the bspwmrc example

### DIFF
--- a/examples/bspwmrc
+++ b/examples/bspwmrc
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-sxhkd &
+pidof sxhkd || { sxhkd & }
 
 bspc monitor -d I II III IV V VI VII VIII IX X
 


### PR DESCRIPTION
Prevents `bspc wm --restart` from running another `sxhkd` instance in the background.

Maybe relevant: [thread](https://www.reddit.com/r/bspwm/comments/hygc1l/lingering_sxhkd_processes_when_restarting_bspwm/)