### PR TITLE
Use `direction_t *` to store split_dir in a `rule_consequence_t` instead of using `char [SMALEN]`.

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -438,7 +438,7 @@ void print_rule_consequence(char **buf, rule_consequence_t *csq)
 	        csq->monitor_desc, csq->desktop_desc, csq->node_desc,
 	        csq->state == NULL ? "" : STATE_STR(*csq->state),
 	        csq->layer == NULL ? "" : LAYER_STR(*csq->layer),
-	        csq->split_dir, csq->split_ratio,
+	        csq->split_dir == NULL ? "" : SPLIT_DIR_STR(*csq->split_dir), csq->split_ratio,
 	        ON_OFF_STR(csq->hidden), ON_OFF_STR(csq->sticky), ON_OFF_STR(csq->private),
 	        ON_OFF_STR(csq->locked), ON_OFF_STR(csq->marked), ON_OFF_STR(csq->center), ON_OFF_STR(csq->follow),
 	        ON_OFF_STR(csq->manage), ON_OFF_STR(csq->focus), ON_OFF_STR(csq->border), rect_buf);

--- a/src/rule.c
+++ b/src/rule.c
@@ -192,6 +192,14 @@ event_queue_t *make_event_queue(xcb_generic_event_t *evt)
 }
 
 
+#define SET_CSQ_SPLIT_DIR(val) \
+	do { \
+		if (csq->split_dir == NULL) { \
+			csq->split_dir = calloc(1, sizeof(direction_t)); \
+		} \
+		*(csq->split_dir) = (val); \
+	} while (0)
+
 #define SET_CSQ_STATE(val) \
 	do { \
 		if (csq->state == NULL) { \
@@ -386,7 +394,10 @@ void parse_key_value(char *key, char *value, rule_consequence_t *csq)
 	} else if (streq("node", key)) {
 		snprintf(csq->node_desc, sizeof(csq->node_desc), "%s", value);
 	} else if (streq("split_dir", key)) {
-		snprintf(csq->split_dir, sizeof(csq->split_dir), "%s", value);
+		direction_t dir;
+		if (parse_direction(value, &dir)) {
+			SET_CSQ_SPLIT_DIR(dir);
+		}
 	} else if (streq("state", key)) {
 		client_state_t cst;
 		if (parse_client_state(value, &cst)) {

--- a/src/types.h
+++ b/src/types.h
@@ -356,8 +356,8 @@ typedef struct {
 	char monitor_desc[MAXLEN];
 	char desktop_desc[MAXLEN];
 	char node_desc[MAXLEN];
-	char split_dir[SMALEN];
 	double split_ratio;
+	direction_t *split_dir;
 	stack_layer_t *layer;
 	client_state_t *state;
 	bool hidden;

--- a/src/window.c
+++ b/src/window.c
@@ -124,11 +124,8 @@ bool manage_window(xcb_window_t win, rule_consequence_t *csq, int fd)
 		f = mon->desk->focus;
 	}
 
-	if (csq->split_dir[0] != '\0' && f != NULL) {
-		direction_t dir;
-		if (parse_direction(csq->split_dir, &dir)) {
-			presel_dir(m, d, f, dir);
-		}
+	if (csq->split_dir != NULL && f != NULL) {
+		presel_dir(m, d, f, *csq->split_dir);
 	}
 
 	if (csq->split_ratio != 0 && f != NULL) {


### PR DESCRIPTION
This also prevents bspwm from passing an invalid `split_dir` to `external_rules_command`.

Related issue #1162