### PR TITLE
Honor `pointer_follows_focus` when swapping nodes

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -1571,6 +1571,9 @@ bool swap_nodes(monitor_t *m1, desktop_t *d1, node_t *n1, monitor_t *m2, desktop
 	} else {
 		draw_border(n1, is_descendant(n1, d2->focus), (m2 == mon));
 		draw_border(n2, is_descendant(n2, d1->focus), (m1 == mon));
+		if (pointer_follows_focus) {
+			center_pointer(get_rectangle(m2, d2, n2));
+		}
 	}
 
 	arrange(m1, d1);


### PR DESCRIPTION
This wasn't the case when swapping nodes on the same desktop.