### PR TITLE
Add layout and user_layout modifiers to desktop selectors. 

### DIFF
--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -211,6 +211,9 @@ DESKTOP_SEL := [DESKTOP_SEL#](CYCLE_DIR|any|last|newest|older|newer|
                               [MONITOR_SEL:](focused|^<n>)|
                               <desktop_id>|<desktop_name>)[.[!]focused][.[!]active]
                                                           [.[!]occupied][.[!]urgent][.[!]local]
+                                                          [.[!]LAYOUT][.[!]user_LAYOUT]
+
+LAYOUT := tiled|monocle
 ----
 
 Descriptors
@@ -263,6 +266,12 @@ Modifiers
 
 [!]local::
 	Only consider desktops inside the reference monitor.
+
+[!](tiled|monocle)::
+	Only consider desktops with the given layout.
+
+[!](user_tiled|user_monocle)::
+	Only consider desktops which have the given layout as userLayout.
 
 Monitor
 ~~~~~~~

--- a/src/parse.c
+++ b/src/parse.c
@@ -503,6 +503,10 @@ bool parse_desktop_modifiers(char *desc, desktop_select_t *sel)
 		GET_MOD(active)
 		GET_MOD(urgent)
 		GET_MOD(local)
+		GET_MOD(tiled)
+		GET_MOD(monocle)
+		GET_MOD(user_tiled)
+		GET_MOD(user_monocle)
 		} else {
 			return false;
 		}

--- a/src/query.c
+++ b/src/query.c
@@ -511,7 +511,11 @@ desktop_select_t make_desktop_select(void)
 		.focused = OPTION_NONE,
 		.active = OPTION_NONE,
 		.urgent = OPTION_NONE,
-		.local = OPTION_NONE
+		.local = OPTION_NONE,
+		.tiled = OPTION_NONE,
+		.monocle = OPTION_NONE,
+		.user_tiled = OPTION_NONE,
+		.user_monocle = OPTION_NONE
 	};
 	return sel;
 }
@@ -1239,6 +1243,28 @@ bool desktop_matches(coordinates_t *loc, coordinates_t *ref, desktop_select_t *s
 	    : sel->local == OPTION_FALSE) {
 		return false;
 	}
+
+#define DLAYOUT(p, e) \
+	if (sel->p != OPTION_NONE && \
+	    loc->desktop->layout != e \
+	    ? sel->p == OPTION_TRUE \
+	    : sel->p == OPTION_FALSE) { \
+		return false; \
+	}
+	DLAYOUT(tiled, LAYOUT_TILED)
+	DLAYOUT(monocle, LAYOUT_MONOCLE)
+#undef DLAYOUT
+
+#define DUSERLAYOUT(p, e) \
+	if (sel->p != OPTION_NONE && \
+	    loc->desktop->user_layout != e \
+	    ? sel->p == OPTION_TRUE \
+	    : sel->p == OPTION_FALSE) { \
+		return false; \
+	}
+	DUSERLAYOUT(user_tiled, LAYOUT_TILED)
+	DUSERLAYOUT(user_monocle, LAYOUT_MONOCLE)
+#undef DUSERLAYOUT
 
 	return true;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -193,6 +193,10 @@ typedef struct {
 	option_bool_t active;
 	option_bool_t urgent;
 	option_bool_t local;
+	option_bool_t tiled;
+	option_bool_t monocle;
+	option_bool_t user_tiled;
+	option_bool_t user_monocle;
 } desktop_select_t;
 
 typedef struct {


### PR DESCRIPTION
Example use cases:

* polybar module that shows an "M" when the focused desktop's layout is `monocle`:
```ini
[module/desktop_monocle]
type = custom/script
exec-if = bspc query -D -d focused.monocle
exec = echo M
```
* go to the next monocle desktop:
```shell
bspc desktop next.user_monocle -f
```
* spawn the next window in a desktop that is monocle only because of `single_monocle` (i.e. desktop with only one tiled leaf node):
```
bspc rule -a \* -o desktop=any.monocle.user_tiled
```

----------------------------

~~I also fixed a mistake in the documentation in the second commit.~~ (moved to a separate Pull Request since it isn't related)