### PR TITLE
Fix `bspc rule -r <^n>` completion for zsh

### DIFF
--- a/contrib/zsh_completion
+++ b/contrib/zsh_completion
@@ -295,7 +295,7 @@ _bspc() {
 					compset -P '*:'
 					bspc rule -l 2> /dev/null |
 						while IFS=" " read target settings ;do
-							by_index+="^$((index++)):${target} ${settings}"
+							by_index+="^$((++index)):${target} ${settings}"
 							if [ -n "$IPREFIX" ] ;then
 								completions+="${target#*:}"
 							else


### PR DESCRIPTION
Indexes were offsetted by one and started from 0.
0 is not a valid index.

Fixes #1193.