### PR TITLE
Improve locate_desktop() and locate_monitor().

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -951,6 +951,8 @@ bool locate_desktop(char *name, coordinates_t *loc)
 			}
 		}
 	}
+	loc->monitor = NULL;
+	loc->desktop = NULL;
 	return false;
 }
 
@@ -962,6 +964,7 @@ bool locate_monitor(char *name, coordinates_t *loc)
 			return true;
 		}
 	}
+	loc->monitor = NULL;
 	return false;
 }
 


### PR DESCRIPTION
In locate_desktop(), loc->monitor and loc->desktop are now set to NULL if no desktop is located.

In locate_monitor(), loc->monitor is now set to NULL if no monitor is located.

This prevents bspwm from crashing if..
```bash
bspc node -m %invalid_name
```
..or..
```bash
bspc node -d %invalid_name
```
..is run.

Fixes #1196.