### PR TITLE
Add media key example hotkeys to sxhkdrc

### DIFF
--- a/examples/sxhkdrc
+++ b/examples/sxhkdrc
@@ -15,6 +15,26 @@ super + Escape
 	pkill -USR1 -x sxhkd
 
 #
+# media keys
+#
+
+# toggle microphone
+XF86AudioMicMute
+	amixer set Capture toggle
+
+# toggle volume
+XF86AudioMute
+	amixer set Master toggle
+
+# adjust volume
+XF86Audio{Lower,Raise}Volume
+	amixer sset Master 2%{-,+}
+
+# adjust brightness
+XF86MonBrightness{Down,Up}{_, + shift}
+	light -{U,A} {2,10}
+
+#
 # bspwm hotkeys
 #
 


### PR DESCRIPTION
The example `sxhkdrc` is pretty bare bones and could use some simple, ~~system-independent~~ changes. I've added hotkeys for some common laptop media keys like adjusting volume and brightness. This helps bspwm work more out-of-the-box. New users may not expect having to manually map their brightness control/volume adjustment.