### PR TITLE
Allow negated window modifiers to match non-window nodes

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1125,6 +1125,31 @@ bool node_matches(coordinates_t *loc, coordinates_t *ref, node_select_t *sel)
 	NFLAG(marked)
 #undef NFLAG
 
+#define NSPLIT(p, e) \
+	if (sel->p != OPTION_NONE && \
+	    loc->node->split_type != e \
+	    ? sel->p == OPTION_TRUE \
+	    : sel->p == OPTION_FALSE) { \
+		return false; \
+	}
+	NSPLIT(horizontal, TYPE_HORIZONTAL)
+	NSPLIT(vertical, TYPE_VERTICAL)
+#undef NSPLIT
+
+	if (sel->descendant_of != OPTION_NONE &&
+	    !is_descendant(loc->node, ref->node)
+	    ? sel->descendant_of == OPTION_TRUE
+	    : sel->descendant_of == OPTION_FALSE) {
+		return false;
+	}
+
+	if (sel->ancestor_of != OPTION_NONE &&
+	    !is_descendant(ref->node, loc->node)
+	    ? sel->ancestor_of == OPTION_TRUE
+	    : sel->ancestor_of == OPTION_FALSE) {
+		return false;
+	}
+
 	if (loc->node->client == NULL &&
 		(sel->same_class != OPTION_NONE ||
 		 sel->tiled != OPTION_NONE ||
@@ -1143,20 +1168,6 @@ bool node_matches(coordinates_t *loc, coordinates_t *ref, node_select_t *sel)
 	    streq(loc->node->client->class_name, ref->node->client->class_name)
 	    ? sel->same_class == OPTION_FALSE
 	    : sel->same_class == OPTION_TRUE) {
-		return false;
-	}
-
-	if (sel->descendant_of != OPTION_NONE &&
-	    !is_descendant(loc->node, ref->node)
-	    ? sel->descendant_of == OPTION_TRUE
-	    : sel->descendant_of == OPTION_FALSE) {
-		return false;
-	}
-
-	if (sel->ancestor_of != OPTION_NONE &&
-	    !is_descendant(ref->node, loc->node)
-	    ? sel->ancestor_of == OPTION_TRUE
-	    : sel->ancestor_of == OPTION_FALSE) {
 		return false;
 	}
 
@@ -1194,20 +1205,6 @@ bool node_matches(coordinates_t *loc, coordinates_t *ref, node_select_t *sel)
 	}
 	WFLAG(urgent)
 #undef WFLAG
-
-	if (sel->horizontal != OPTION_NONE &&
-	    loc->node->split_type != TYPE_HORIZONTAL
-	    ? sel->horizontal == OPTION_TRUE
-	    : sel->horizontal == OPTION_FALSE) {
-		return false;
-	}
-
-	if (sel->vertical != OPTION_NONE &&
-	    loc->node->split_type != TYPE_VERTICAL
-	    ? sel->vertical == OPTION_TRUE
-	    : sel->vertical == OPTION_FALSE) {
-		return false;
-	}
 
 	return true;
 }

--- a/src/query.c
+++ b/src/query.c
@@ -1150,17 +1150,19 @@ bool node_matches(coordinates_t *loc, coordinates_t *ref, node_select_t *sel)
 		return false;
 	}
 
-	if (loc->node->client == NULL &&
-		(sel->same_class != OPTION_NONE ||
-		 sel->tiled != OPTION_NONE ||
-		 sel->pseudo_tiled != OPTION_NONE ||
-		 sel->floating != OPTION_NONE ||
-		 sel->fullscreen != OPTION_NONE ||
-		 sel->below != OPTION_NONE ||
-		 sel->normal != OPTION_NONE ||
-		 sel->above != OPTION_NONE ||
-		 sel->urgent != OPTION_NONE)) {
-		return false;
+	if (loc->node->client == NULL) {
+		if (sel->same_class == OPTION_TRUE ||
+		    sel->tiled == OPTION_TRUE ||
+		    sel->pseudo_tiled == OPTION_TRUE ||
+		    sel->floating == OPTION_TRUE ||
+		    sel->fullscreen == OPTION_TRUE ||
+		    sel->below == OPTION_TRUE ||
+		    sel->normal == OPTION_TRUE ||
+		    sel->above == OPTION_TRUE ||
+		    sel->urgent == OPTION_TRUE) {
+			return false;
+		}
+		return true;
 	}
 
 	if (ref->node != NULL && ref->node->client != NULL &&


### PR DESCRIPTION
For example, `.!floating` used to only match nodes that hold a window that are not in floating state; now, `.!floating` will match any node that is not a window node in floating state.

To use the old behaviour, you can just use the negated window modifier with `.window`; e.g.:
* `.!floating` -> `.!floating.window`
* `.!same_class` -> `.!same_class.window`
* `.!hidden.!sticky` -> `.!hidden.!sticky.window`

In my opinion, the old behaviour was counterintuitive since, e.g., `.tiled` and `.!tiled` were not complementary and because of the way this was reported on the manual page.
