### PR TITLE
Honor `pointer_follows_focus` when node commands change the tree

### DIFF
--- a/src/messages.c
+++ b/src/messages.c
@@ -595,6 +595,9 @@ void cmd_node(char **args, int num, FILE *rsp)
 
 	if (changed) {
 		arrange(trg.monitor, trg.desktop);
+		if (pointer_follows_focus) {
+			center_pointer(get_rectangle(mon, mon->desk, mon->desk->focus));
+		}
 	}
 }
 


### PR DESCRIPTION
This centers the pointer after e.g. rotating a tree or balancing the node ratios.