### PR TITLE
`node -t ~` can now be used to restore the last state unconditionally.

### DIFF
--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -452,8 +452,8 @@ Commands
 *-C*, *--circulate* forward|backward::
 	Circulate the windows of the tree rooted at the selected node.
 
-*-t*, *--state* [~](tiled|pseudo_tiled|floating|fullscreen)::
-	Set the state of the selected window. If *~* is present and the current state matches the given state, then the argument is interpreted as the last state.
+*-t*, *--state* \~|\[~]'STATE'::
+	Set the state of the selected window. If *\~* is present and the current state matches 'STATE', then the argument is interpreted as its last state. If the argument is just *~* with 'STATE' omitted, then the state of the selected window is set to its last state.
 
 *-g*, *--flag* hidden|sticky|private|locked|marked[=on|off]::
 	Set or toggle the given flag for the selected node.

--- a/src/messages.c
+++ b/src/messages.c
@@ -296,20 +296,27 @@ void cmd_node(char **args, int num, FILE *rsp)
 				alternate = true;
 				(*args)++;
 			}
-			if (parse_client_state(*args, &cst)) {
+			if (alternate && (*args)[0] == '\0') {
+				if (trg.node != NULL && trg.node->client != NULL) {
+					cst = trg.node->client->last_state;
+				} else {
+					fail(rsp, "");
+					break;
+				}
+			} else if (parse_client_state(*args, &cst)) {
 				if (alternate && trg.node != NULL && trg.node->client != NULL &&
 				    trg.node->client->state == cst) {
 					cst = trg.node->client->last_state;
 				}
-				if (!set_state(trg.monitor, trg.desktop, trg.node, cst)) {
-					fail(rsp, "");
-					break;
-				}
-				changed = true;
 			} else {
 				fail(rsp, "node %s: Invalid argument: '%s'.\n", *(args - 1), *args);
 				break;
 			}
+			if (!set_state(trg.monitor, trg.desktop, trg.node, cst)) {
+				fail(rsp, "");
+				break;
+			}
+			changed = true;
 		} else if (streq("-g", *args) || streq("--flag", *args)) {
 			num--, args++;
 			if (num < 1) {


### PR DESCRIPTION
Currently, to restore the last state (without using `query -T -n`), you have to use this sequence of ORed commands.
```bash
# restore the last state of the focused window
bspc node focused.tiled -t '~tiled' \
    || bspc node focused.pseudo_tiled -t '~pseudo_tiled' \
    || bspc node focused.fullscreen -t '~fullscreen' \
    || bspc node focused.floating -t '~floating'
```

Simply restoring the last state should not be made that complex, we now allow passing `~` to `node -t` to restore the last state:
```bash
# restore the last state of the focused window
bspc node -t '~'
```

This also simplifies this kind of operations:
```bash
# if the state of the focused window is neither tiled nor pseudo_tiled,
#  change its state to its last state;
#  if its state is still neither pseudo_tiled nor tiled, change its state
#  to tiled.
if
    bspc node focused.fullscreen -t '~fullscreen' \
        || bspc node focused.floating -t '~floating'
then
    bspc node 'focused.!tiled.!pseudo_tiled.window' -t tiled
fi
```
To:
```bash
# if the state of the focused window is neither tiled nor pseudo_tiled,
#  change its state to its last state;
#  if its state is still neither pseudo_tiled nor tiled, change its state
#  to tiled.
bspc node 'focused.!pseudo_tiled.!tiled.window' -t '~' \
    && bspc node 'focused.!pseudo_tiled.!tiled.window' -t tiled
```