### PR TITLE
Change split type (vertical|horizontal) of a node

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -723,6 +723,11 @@ Rotate the tree rooted at the selected node\&.
 Flip the the tree rooted at selected node\&.
 .RE
 .PP
+\fB\-S\fR, \fB\-\-set\-split\fR \fIhorizontal|vertical\fR
+.RS 4
+Set the split type at selected node\&.
+.RE
+.PP
 \fB\-E\fR, \fB\-\-equalize\fR
 .RS 4
 Reset the split ratios of the tree rooted at the selected node to their default value\&.

--- a/src/messages.c
+++ b/src/messages.c
@@ -541,6 +541,24 @@ void cmd_node(char **args, int num, FILE *rsp)
 			}
 			balance_tree(trg.node);
 			changed = true;
+		} else if (streq("-S", *args) || streq("--set-split", *args)) {
+			num--, args++;
+			if (num < 1) {
+				fail(rsp, "node %s: Not enough arguments.\n", *(args - 1));
+				break;
+			}
+			if (trg.node == NULL) {
+				fail(rsp, "");
+				break;
+			}
+			split_type_t t;
+			if (parse_split_type(*args, &t)) {
+				set_split_type(trg.node, t);
+			} else {
+				fail(rsp, "node %s: Invalid argument: '%s'.\n", *(args - 1), *args);
+				break;
+			}
+			changed = true;
 		} else if (streq("-C", *args) || streq("--circulate", *args)) {
 			num--, args++;
 			if (num < 1) {

--- a/src/tree.c
+++ b/src/tree.c
@@ -2240,6 +2240,11 @@ void regenerate_ids_in(node_t *n)
 	regenerate_ids_in(n->second_child);
 }
 
+void set_split_type(node_t *n, split_type_t t)
+{
+	n->split_type = t;
+}
+
 #define DEF_FLAG_COUNT(flag) \
 	unsigned int flag##_count(node_t *n) \
 	{ \

--- a/src/tree.h
+++ b/src/tree.h
@@ -114,6 +114,7 @@ void set_urgent(monitor_t *m, desktop_t *d, node_t *n, bool value);
 xcb_rectangle_t get_rectangle(monitor_t *m, desktop_t *d, node_t *n);
 void listen_enter_notify(node_t *n, bool enable);
 void regenerate_ids_in(node_t *n);
+void set_split_type(node_t *n, split_type_t t);
 
 unsigned int sticky_count(node_t *n);
 unsigned int private_count(node_t *n);


### PR DESCRIPTION
This is neither addressed by rotate nor flip AFAIK.
The goal is to be able to change the split direction of a node, without changing the tree.

Example use case: I have a custom rule to stack things vertically unconditionally. Sometimes it's great, sometimes I prefer a two-column layout, so I just change the split direction of the root node.
Rotating the tree here would change the node (partial) order, which is undesirable in this context.