### PR TITLE
Remove pointer_action events from the "node" mask.

### DIFF
--- a/src/subscribe.h
+++ b/src/subscribe.h
@@ -58,7 +58,7 @@ typedef enum {
 	SBSC_MASK_POINTER_ACTION = 1 << 27,
 	SBSC_MASK_MONITOR = (1 << 7) - (1 << 1),
 	SBSC_MASK_DESKTOP = (1 << 15) - (1 << 7),
-	SBSC_MASK_NODE = (1 << 28) - (1 << 15),
+	SBSC_MASK_NODE = (1 << 27) - (1 << 15),
 	SBSC_MASK_ALL = (1 << 28) - 1
 } subscriber_mask_t;
 


### PR DESCRIPTION
`pointer_action` events are included in the `node` event mask; this is a little weird and I think it is not intended.

------

* open a floating terminal window
* run `bspc subscribe node`
* move the terminal window with your mouse
* RESULT without this patch:
  ```
  pointer_action 0x00C00006 0x00C00007 0x008018A2 move begin                      
  pointer_action 0x00C00006 0x00C00007 0x008018A2 move end                        
  node_geometry 0x00C00006 0x00C00007 0x008018A2 644x388+384+197
  ```
* RESULT with this patch:
  ```
  node_geometry 0x00A00002 0x00A00004 0x008000BB 644x388+536+157
  ```