### PR TITLE
Allow cycling the splitting type of a node with `node -y CYCLE_DIR`

### DIFF
--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -434,8 +434,8 @@ Commands
 *-z*, *--resize* top|left|bottom|right|top_left|top_right|bottom_right|bottom_left 'dx' 'dy'::
 	Resize the selected window by moving the given handle by 'dx' pixels horizontally and 'dy' pixels vertically.
 
-*-y*, *--type* 'horizontal|vertical'::
-	Set the splitting type of the selected node.
+*-y*, *--type* 'CYCLE_DIR'|horizontal|vertical::
+	Set or cycle the splitting type of the selected node.
 
 *-r*, *--ratio* 'RATIO'|(+|-)('PIXELS'|'FRACTION')::
 	Set the splitting ratio of the selected node (0 < 'RATIO' < 1).

--- a/src/messages.c
+++ b/src/messages.c
@@ -468,14 +468,17 @@ void cmd_node(char **args, int num, FILE *rsp)
 				fail(rsp, "");
 				break;
 			}
+			cycle_dir_t cyc;
 			split_type_t typ;
-			if (parse_split_type(*args, &typ)) {
+			if (parse_cycle_direction(*args, &cyc)) {
+				set_type(trg.node, (trg.node->split_type + 1) % 2);
+			} else if (parse_split_type(*args, &typ)) {
 				set_type(trg.node, typ);
-				changed = true;
 			} else {
 				fail(rsp, "");
 				break;
 			}
+			changed = true;
 		} else if (streq("-r", *args) || streq("--ratio", *args)) {
 			num--, args++;
 			if (num < 1) {


### PR DESCRIPTION
similar to `dekstop -l CYCLE_DIR`