### PR TITLE
escape the colon (:) character belonging to a window name

### DIFF
--- a/src/messages.c
+++ b/src/messages.c
@@ -1173,7 +1173,9 @@ void cmd_rule(char **args, int num, FILE *rsp)
 			rule_t *rule = make_rule();
 			char *class_name = strtok(*args, COL_TOK);
 			char *instance_name = strtok(NULL, COL_TOK);
-			char *name = strtok(NULL, COL_TOK);
+                        char *name = NULL;
+                        if (class_name && instance_name)
+                        	name = *args + strlen(class_name) + strlen(instance_name) + 2;
 			snprintf(rule->class_name, sizeof(rule->class_name), "%s", class_name);
 			snprintf(rule->instance_name, sizeof(rule->instance_name), "%s", instance_name==NULL?MATCH_ANY:instance_name);
 			snprintf(rule->name, sizeof(rule->name), "%s", name==NULL?MATCH_ANY:name);

--- a/src/messages.c
+++ b/src/messages.c
@@ -1173,9 +1173,9 @@ void cmd_rule(char **args, int num, FILE *rsp)
 			rule_t *rule = make_rule();
 			char *class_name = strtok(*args, COL_TOK);
 			char *instance_name = strtok(NULL, COL_TOK);
-                        char *name = NULL;
-                        if (class_name && instance_name)
-                        	name = *args + strlen(class_name) + strlen(instance_name) + 2;
+			char *name = NULL;
+			if (class_name && instance_name)
+				name = *args + strlen(class_name) + strlen(instance_name) + 2;
 			snprintf(rule->class_name, sizeof(rule->class_name), "%s", class_name);
 			snprintf(rule->instance_name, sizeof(rule->instance_name), "%s", instance_name==NULL?MATCH_ANY:instance_name);
 			snprintf(rule->name, sizeof(rule->name), "%s", name==NULL?MATCH_ANY:name);


### PR DESCRIPTION
While dealing with bspc rules, I faced windows with name that contains colons (:).
Ex: WM_NAME(STRING) = "VM1 [Running] - Oracle VM VirtualBox : 1"

A simple fix is to not use strtok for the window name and consider the remaining string (the third token) as the window name.