### PR TITLE
Border colors for marked nodes

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -1174,6 +1174,11 @@ Color of the
 message feedback area\&.
 .RE
 .PP
+\fImarked_border_color\fR
+.RS 4
+Color of the border of a marked window\&.
+.RE
+.PP
 \fIsplit_ratio\fR
 .RS 4
 Default split ratio\&.

--- a/src/messages.c
+++ b/src/messages.c
@@ -1604,6 +1604,8 @@ void set_setting(coordinates_t loc, char *name, char *value, FILE *rsp)
 	SET_COLOR(active_border_color)
 	SET_COLOR(focused_border_color)
 	SET_COLOR(presel_feedback_color)
+	SET_COLOR(marked_border_color)
+
 #undef SET_COLOR
 	} else if (streq("initial_polarity", name)) {
 		child_polarity_t p;
@@ -1851,6 +1853,8 @@ void get_setting(coordinates_t loc, char *name, FILE* rsp)
 	GET_COLOR(active_border_color)
 	GET_COLOR(focused_border_color)
 	GET_COLOR(presel_feedback_color)
+	GET_COLOR(marked_border_color)
+	
 #undef GET_COLOR
 #define GET_BOOL(s) \
 	} else if (streq(#s, name)) { \

--- a/src/settings.c
+++ b/src/settings.c
@@ -35,6 +35,7 @@ char normal_border_color[MAXLEN];
 char active_border_color[MAXLEN];
 char focused_border_color[MAXLEN];
 char presel_feedback_color[MAXLEN];
+char marked_border_color[MAXLEN];
 
 padding_t padding;
 padding_t monocle_padding;
@@ -96,6 +97,7 @@ void load_settings(void)
 	snprintf(active_border_color, sizeof(active_border_color), "%s", ACTIVE_BORDER_COLOR);
 	snprintf(focused_border_color, sizeof(focused_border_color), "%s", FOCUSED_BORDER_COLOR);
 	snprintf(presel_feedback_color, sizeof(presel_feedback_color), "%s", PRESEL_FEEDBACK_COLOR);
+	snprintf(marked_border_color, sizeof(marked_border_color), "%s", MARKED_BORDER_COLOR);
 
 	padding = (padding_t) PADDING;
 	monocle_padding = (padding_t) MONOCLE_PADDING;

--- a/src/settings.h
+++ b/src/settings.h
@@ -36,6 +36,7 @@
 #define ACTIVE_BORDER_COLOR           "#474645"
 #define FOCUSED_BORDER_COLOR          "#817f7f"
 #define PRESEL_FEEDBACK_COLOR         "#f4d775"
+#define MARKED_BORDER_COLOR           "#DD0840"
 
 #define PADDING              {0, 0, 0, 0}
 #define MONOCLE_PADDING      {0, 0, 0, 0}
@@ -75,6 +76,7 @@ extern char normal_border_color[MAXLEN];
 extern char active_border_color[MAXLEN];
 extern char focused_border_color[MAXLEN];
 extern char presel_feedback_color[MAXLEN];
+extern char marked_border_color[MAXLEN];
 
 extern padding_t padding;
 extern padding_t monocle_padding;

--- a/src/tree.c
+++ b/src/tree.c
@@ -488,7 +488,7 @@ bool activate_node(monitor_t *m, desktop_t *d, node_t *n)
 		if (d->focus != n) {
 			for (node_t *f = first_extrema(d->focus); f != NULL; f = next_leaf(f, d->focus)) {
 				if (f->client != NULL && !is_descendant(f, n)) {
-					window_draw_border(f->id, get_border_color(false, (m == mon)));
+					window_draw_border(f->id, get_border_color(f->marked, false, (m == mon)));
 				}
 			}
 		}
@@ -614,7 +614,7 @@ bool focus_node(monitor_t *m, desktop_t *d, node_t *n)
 	if (d->focus != n) {
 		for (node_t *f = first_extrema(d->focus); f != NULL; f = next_leaf(f, d->focus)) {
 			if (f->client != NULL && !is_descendant(f, n)) {
-				window_draw_border(f->id, get_border_color(false, true));
+				window_draw_border(f->id, get_border_color(f->marked, false, true));
 			}
 		}
 	}

--- a/src/window.c
+++ b/src/window.c
@@ -408,7 +408,7 @@ void draw_border(node_t *n, bool focused_node, bool focused_monitor)
 		return;
 	}
 
-	uint32_t border_color_pxl = get_border_color(focused_node, focused_monitor);
+	uint32_t border_color_pxl = get_border_color(n->marked, focused_node, focused_monitor);
 	for (node_t *f = first_extrema(n); f != NULL; f = next_leaf(f, n)) {
 		if (f->client != NULL) {
 			window_draw_border(f->id, border_color_pxl);
@@ -442,12 +442,14 @@ void adopt_orphans(void)
 	free(qtr);
 }
 
-uint32_t get_border_color(bool focused_node, bool focused_monitor)
+uint32_t get_border_color(bool marked, bool focused_node, bool focused_monitor)
 {
 	if (focused_monitor && focused_node) {
 		return get_color_pixel(focused_border_color);
 	} else if (focused_node) {
 		return get_color_pixel(active_border_color);
+	} else if (marked) {
+		return get_color_pixel(marked_border_color);
 	} else {
 		return get_color_pixel(normal_border_color);
 	}

--- a/src/window.h
+++ b/src/window.h
@@ -46,7 +46,7 @@ void update_colors_in(node_t *n, desktop_t *d, monitor_t *m);
 void draw_border(node_t *n, bool focused_node, bool focused_monitor);
 void window_draw_border(xcb_window_t win, uint32_t border_color_pxl);
 void adopt_orphans(void);
-uint32_t get_border_color(bool focused_node, bool focused_monitor);
+uint32_t get_border_color(bool marked, bool focused_node, bool focused_monitor);
 void initialize_floating_rectangle(node_t *n);
 xcb_rectangle_t get_window_rectangle(node_t *n);
 bool move_client(coordinates_t *loc, int dx, int dy);


### PR DESCRIPTION
Hey!
I thought that it would be nice to have a visual indicator for a "marked" node to distinguish it from normal nodes.
One can argue that a marked node is mostly only used for swapping and hence a visual indicator is not required to remember which node was marked, but when you mark nodes on other desktops/monitors simultaneously, then it can be really helpful.

Also, note that when you select the marked node, it's border color gets overridden by `focused_border_color`

I tested `bspc config marked_border_color #HEX` and it seems to run fine as well!