### PR TITLE
Add optional includes for BSD, and explicit rules for bspwm and bspc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,23 @@
 VERCMD  ?= git describe --tags 2> /dev/null
 VERSION := $(shell $(VERCMD) || cat VERSION)
+UNAME_S := $(shell uname -s)
 
-# Linux
-X11INC = -I/usr/include
-X11LIB = -L/usr/lib
+ifeq ($(UNAME_S), OpenBSD)
+	X11INC = -I/usr/X11R6/include
+	X11LIB = -L/usr/X11R6/lib
+else ifeq ($(UNAME_S), FreeBSD)
+	X11INC = -I/usr/local/incldue
+	X11LIB = -L/usr/local/lib
+else
+	X11INC = -I/usr/include
+	X11LIB = -L/usr/lib
+endif
 
-# OpenBSD
-# X11INC = -I/usr/X11R6/include
-# X11LIB = -L/usr/X11R6/lib
+CFLAGS  = $(X11INC) -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\" \
+	-std=c99 -pedantic -Wall -Wextra -DJSMN_STRICT
 
-# FreeBSD
-# X11INC = -I/usr/local/incldue
-# X11LIB = -L/usr/local/lib
-
-CFLAGS  = $(X11INC) -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\" -std=c99 -pedantic -Wall -Wextra -DJSMN_STRICT
-LDFLAGS = $(X11LIB) -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh -lxcb-randr -lxcb-xinerama -lxcb-shape
+LDFLAGS = $(X11LIB) -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh \
+	-lxcb-randr -lxcb-xinerama -lxcb-shape
 
 PREFIX    ?= /usr/local
 BINPREFIX ?= $(PREFIX)/bin
@@ -45,10 +48,8 @@ include Sourcedeps
 $(WM_OBJ) $(CLI_OBJ): Makefile
 
 bspwm: $(WM_OBJ)
-	$(CC) $(LDFLAGS) $(WM_OBJ) -o $@
 
 bspc: $(CLI_OBJ)
-	$(CC) $(LDFLAGS) $(CLI_OBJ) -o $@
 
 install:
 	mkdir -p "$(DESTDIR)$(BINPREFIX)"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,23 @@
+.POSIX:
+
 VERCMD  ?= git describe --tags 2> /dev/null
 VERSION := $(shell $(VERCMD) || cat VERSION)
+CC       = cc
 
-CPPFLAGS += -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\"
-CFLAGS   += -std=c99 -pedantic -Wall -Wextra -DJSMN_STRICT
-LDFLAGS  ?=
-LDLIBS    = $(LDFLAGS) -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh -lxcb-randr -lxcb-xinerama -lxcb-shape
+# Linux
+X11INC = -I/usr/include
+X11LIB = -L/usr/lib
+
+# OpenBSD
+# X11INC = -I/usr/X11R6/include
+# X11LIB = -L/usr/X11R6/lib
+
+# FreeBSD
+# X11INC = -I/usr/local/incldue
+# X11LIB = -L/usr/local/lib
+
+CFLAGS  = $(X11INC) -D_POSIX_C_SOURCE=200809L -DVERSION=\"$(VERSION)\" -std=c99 -pedantic -Wall -Wextra -DJSMN_STRICT
+LDFLAGS = $(X11LIB) -lm -lxcb -lxcb-util -lxcb-keysyms -lxcb-icccm -lxcb-ewmh -lxcb-randr -lxcb-xinerama -lxcb-shape
 
 PREFIX    ?= /usr/local
 BINPREFIX ?= $(PREFIX)/bin
@@ -35,8 +48,10 @@ include Sourcedeps
 $(WM_OBJ) $(CLI_OBJ): Makefile
 
 bspwm: $(WM_OBJ)
+	$(CC) $(LDFLAGS) $(WM_OBJ) -o $@
 
 bspc: $(CLI_OBJ)
+	$(CC) $(LDFLAGS) $(CLI_OBJ) -o $@
 
 install:
 	mkdir -p "$(DESTDIR)$(BINPREFIX)"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
-.POSIX:
-
 VERCMD  ?= git describe --tags 2> /dev/null
 VERSION := $(shell $(VERCMD) || cat VERSION)
-CC       = cc
 
 # Linux
 X11INC = -I/usr/include

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ($(UNAME_S), OpenBSD)
 	X11INC = -I/usr/X11R6/include
 	X11LIB = -L/usr/X11R6/lib
 else ifeq ($(UNAME_S), FreeBSD)
-	X11INC = -I/usr/local/incldue
+	X11INC = -I/usr/local/include
 	X11LIB = -L/usr/local/lib
 else
 	X11INC = -I/usr/include


### PR DESCRIPTION
Building BSPWM with `make` fails on OpenBSD 7.0 and FreeBSD 13.0. Errors include failure to find required headers and libraries, and failure to find make rules for `bspwm` and `bspc`. The issues regarding missing headers can be attributed to the differences in where xcb is installed on these systems, and the issue regarding `bspwm` and `bspc` can be attributed to the differences in implicit rules between the GNU and BSD versions of `make`. Adding includes for each OS, and adding an explicit rule for `bspwm` and `bspc` seeks to remedy these issues.

