### PR TITLE
bspc rule -a: allow escaping colons in rule tokenization

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -2,12 +2,12 @@
 .\"     Title: bspwm
 .\"    Author: [see the "Author" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 06/01/2021
+.\"      Date: 01/05/2022
 .\"    Manual: Bspwm Manual
-.\"    Source: Bspwm 0.9.10-31-ge21ab5b
+.\"    Source: Bspwm 0.9.10-33-ge22d0fa
 .\"  Language: English
 .\"
-.TH "BSPWM" "1" "06/01/2021" "Bspwm 0\&.9\&.10\-31\-ge21ab5b" "Bspwm Manual"
+.TH "BSPWM" "1" "01/05/2022" "Bspwm 0\&.9\&.10\-33\-ge22d0fa" "Bspwm Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -1059,7 +1059,11 @@ rule \fICOMMANDS\fR
 .PP
 \fB\-a\fR, \fB\-\-add\fR (<class_name>|*)[:(<instance_name>|*)[:(<name>|*)]] [\fB\-o\fR|\fB\-\-one\-shot\fR] [monitor=MONITOR_SEL|desktop=DESKTOP_SEL|node=NODE_SEL] [state=STATE] [layer=LAYER] [split_dir=DIR] [split_ratio=RATIO] [(hidden|sticky|private|locked|marked|center|follow|manage|focus|border)=(on|off)] [rectangle=WxH+X+Y]
 .RS 4
-Create a new rule\&.
+Create a new rule\&. Colons in the
+\fIinstance_name\fR,
+\fIclass_name\fR, or
+\fIname\fR
+fields can be escaped with a backslash\&.
 .RE
 .PP
 \fB\-r\fR, \fB\-\-remove\fR ^<n>|head|tail|(<class_name>|*)[:(<instance_name>|*)[:(<name>|*)]]\&...

--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -628,7 +628,8 @@ Commands
 ^^^^^^^^
 
 *-a*, *--add* (<class_name>|\*)[:(<instance_name>|\*)[:(<name>|\*)]] [*-o*|*--one-shot*] [monitor=MONITOR_SEL|desktop=DESKTOP_SEL|node=NODE_SEL] [state=STATE] [layer=LAYER] [split_dir=DIR] [split_ratio=RATIO] [(hidden|sticky|private|locked|marked|center|follow|manage|focus|border)=(on|off)] [rectangle=WxH+X+Y]::
-	Create a new rule.
+	Create a new rule. Colons in the 'instance_name', 'class_name', or 'name'
+	fields can be escaped with a backslash.
 
 *-r*, *--remove* ^<n>|head|tail|(<class_name>|\*)[:(<instance_name>|\*)[:(<name>|*)]]...::
 	Remove the given rules.

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -193,3 +193,40 @@ bool is_hex_color(const char *color)
 	}
 	return true;
 }
+
+char *tokenize_with_escape(struct tokenize_state *state, const char *s, char sep)
+{
+	if (s != NULL) {
+		// first call
+		state->in_escape = false;
+		state->pos = s;
+		state->len = strlen(s) + 1;
+	}
+
+	char *outp = calloc(state->len, 1);
+	char *ret = outp;
+	if (!outp) return NULL;
+
+	char cur;
+	while (*state->pos) {
+		--state->len;
+		cur = *state->pos++;
+
+		if (state->in_escape) {
+			*outp++ = cur;
+			state->in_escape = false;
+			continue;
+		}
+
+		if (cur == '\\') {
+			state->in_escape = !state->in_escape;
+		} else if (cur == sep) {
+			return ret;
+		} else {
+			*outp++ = cur;
+		}
+	}
+
+	return ret;
+}
+

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -84,4 +84,11 @@ int asprintf(char **buf, const char *fmt, ...);
 int vasprintf(char **buf, const char *fmt, va_list args);
 bool is_hex_color(const char *color);
 
+struct tokenize_state {
+	bool in_escape;
+	const char *pos;
+	size_t len;
+};
+char *tokenize_with_escape(struct tokenize_state *state, const char *s, char sep);
+
 #endif

--- a/src/messages.c
+++ b/src/messages.c
@@ -1171,12 +1171,27 @@ void cmd_rule(char **args, int num, FILE *rsp)
 				return;
 			}
 			rule_t *rule = make_rule();
-			char *class_name = strtok(*args, COL_TOK);
-			char *instance_name = strtok(NULL, COL_TOK);
-			char *name = strtok(NULL, COL_TOK);
+
+			struct tokenize_state state;
+			char *class_name = tokenize_with_escape(&state, args[0], COL_TOK[0]);
+			char *instance_name = tokenize_with_escape(&state, NULL, COL_TOK[0]);
+			char *name = tokenize_with_escape(&state, NULL, COL_TOK[0]);
+			if (!class_name || !instance_name || !name) {
+				free(class_name);
+				free(instance_name);
+				free(name);
+				return;
+			}
+
 			snprintf(rule->class_name, sizeof(rule->class_name), "%s", class_name);
-			snprintf(rule->instance_name, sizeof(rule->instance_name), "%s", instance_name==NULL?MATCH_ANY:instance_name);
-			snprintf(rule->name, sizeof(rule->name), "%s", name==NULL?MATCH_ANY:name);
+			snprintf(rule->instance_name, sizeof(rule->instance_name), "%s",
+					 instance_name[0] == '\0' ? MATCH_ANY : instance_name);
+			snprintf(rule->name, sizeof(rule->name), "%s",
+					 name[0] == '\0' ? MATCH_ANY : name);
+			free(class_name);
+			free(instance_name);
+			free(name);
+
 			num--, args++;
 			size_t i = 0;
 			while (num > 0) {

--- a/src/rule.c
+++ b/src/rule.c
@@ -81,9 +81,17 @@ void remove_rule(rule_t *r)
 void remove_rule_by_cause(char *cause)
 {
 	rule_t *r = rule_head;
-	char *class_name = strtok(cause, COL_TOK);
-	char *instance_name = strtok(NULL, COL_TOK);
-	char *name = strtok(NULL, COL_TOK);
+	struct tokenize_state state;
+	char *class_name = tokenize_with_escape(&state, cause, COL_TOK[0]);
+	char *instance_name = tokenize_with_escape(&state, NULL, COL_TOK[0]);
+	char *name = tokenize_with_escape(&state, NULL, COL_TOK[0]);
+	if (!class_name || !instance_name || !name) {
+		free(class_name);
+		free(instance_name);
+		free(name);
+		return;
+	}
+
 	while (r != NULL) {
 		rule_t *next = r->next;
 		if ((class_name != NULL && (streq(class_name, MATCH_ANY) || streq(r->class_name, class_name))) &&
@@ -93,6 +101,9 @@ void remove_rule_by_cause(char *cause)
 		}
 		r = next;
 	}
+	free(class_name);
+	free(instance_name);
+	free(name);
 }
 
 bool remove_rule_by_index(int idx)

--- a/tests/node/flags
+++ b/tests/node/flags
@@ -12,9 +12,9 @@ bspc node -g sticky
 
 sticky_node_id=$(bspc query -N -n)
 
-bspc rule -a Test:test -o desktop="test-sticky-b"
+bspc rule -a 'Blah\:\:2:test' -o desktop="test-sticky-b"
 
-window add
+CLASS_NAME=Blah::2 INSTANCE_NAME=test window add
 
 bspc desktop -f "test-sticky-b"
 

--- a/tests/prelude
+++ b/tests/prelude
@@ -10,9 +10,12 @@ window() {
 	local iter=${2:-1}
 	local delta=${3:-1}
 	local event=node_${action}
+	local instance_name=${INSTANCE_NAME:-test}
+	local class_name=${CLASS_NAME:-Test}
+
 	local cmd
 	case "$action" in
-		add) cmd=./test_window ;;
+		add) cmd="./test_window $instance_name $class_name" ;;
 		remove) cmd="bspc node -c" ;;
 	esac
 	while [ $iter -gt 0 ] ; do


### PR DESCRIPTION
Currently, it's impossible to add rules to match windows with colons in their titles/window classes/etc, since the rule parser uses `strtok`, which does not support escaping colons. This PR introduces and uses a new tokenization function that supports escaping.

Fix #1071.