### PR TITLE
Add --print-socket-path option

### DIFF
--- a/doc/bspwm.1
+++ b/doc/bspwm.1
@@ -2,12 +2,12 @@
 .\"     Title: bspwm
 .\"    Author: [see the "Author" section]
 .\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
-.\"      Date: 02/15/2022
+.\"      Date: 03/08/2022
 .\"    Manual: Bspwm Manual
-.\"    Source: Bspwm 0.9.10-34-g3403bb2
+.\"    Source: Bspwm 0.9.10-36-g1560df3
 .\"  Language: English
 .\"
-.TH "BSPWM" "1" "02/15/2022" "Bspwm 0\&.9\&.10\-34\-g3403bb2" "Bspwm Manual"
+.TH "BSPWM" "1" "03/08/2022" "Bspwm 0\&.9\&.10\-36\-g1560df3" "Bspwm Manual"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -33,6 +33,8 @@ bspwm \- Binary space partitioning window manager
 .sp
 \fBbspwm\fR [\fB\-h\fR|\fB\-v\fR|\fB\-c\fR \fICONFIG_PATH\fR]
 .sp
+\fBbspc \-\-print\-socket\-path\fR
+.sp
 \fBbspc\fR \fIDOMAIN\fR [\fISELECTOR\fR] \fICOMMANDS\fR
 .sp
 \fBbspc\fR \fICOMMAND\fR [\fIOPTIONS\fR] [\fIARGUMENTS\fR]
@@ -56,6 +58,13 @@ Print the version and exit\&.
 \fB\-c\fR \fICONFIG_PATH\fR
 .RS 4
 Use the given configuration file\&.
+.RE
+.PP
+\fB\-\-print\-socket\-path\fR
+.RS 4
+Print the
+\fBbspwm\fR
+socket path and exit\&.
 .RE
 .SH "COMMON DEFINITIONS"
 .sp

--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -15,6 +15,8 @@ Synopsis
 
 *bspwm* [*-h*|*-v*|*-c* 'CONFIG_PATH']
 
+*bspc --print-socket-path*
+
 *bspc* 'DOMAIN' ['SELECTOR'] 'COMMANDS'
 
 *bspc* 'COMMAND' ['OPTIONS'] ['ARGUMENTS']
@@ -38,6 +40,9 @@ Options
 
 *-c* 'CONFIG_PATH'::
 	Use the given configuration file.
+
+*--print-socket-path*::
+    Print the *bspwm* socket path and exit.
 
 Common Definitions
 ------------------

--- a/src/bspc.c
+++ b/src/bspc.c
@@ -46,10 +46,6 @@ int main(int argc, char *argv[])
 	sock_address.sun_family = AF_UNIX;
 	char *sp;
 
-	if ((sock_fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
-		err("Failed to create the socket.\n");
-	}
-
 	sp = getenv(SOCKET_ENV_VAR);
 	if (sp != NULL) {
 		snprintf(sock_address.sun_path, sizeof(sock_address.sun_path), "%s", sp);
@@ -60,6 +56,15 @@ int main(int argc, char *argv[])
 			snprintf(sock_address.sun_path, sizeof(sock_address.sun_path), SOCKET_PATH_TPL, host, dn, sn);
 		}
 		free(host);
+	}
+	
+	if (streq(argv[1], "--print-socket-path")) {
+		printf("%s", sock_address.sun_path);
+		return EXIT_SUCCESS;
+	}
+
+	if ((sock_fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+		err("Failed to create the socket.\n");
 	}
 
 	if (connect(sock_fd, (struct sockaddr *) &sock_address, sizeof(sock_address)) == -1) {


### PR DESCRIPTION
This adds an option to `bspc` which prints the socket path to `bspwm` and immediately exits.

The reason for this change is twofold:
- It allows for a convenient way to get `bspwm`'s socket path.
- If the socket path configuration ever changes, then `bspc --print-socket-path` will still work, whereas manually composing it will not.