### PR TITLE
Always return 1 when execvp() fails.

### DIFF
--- a/src/bspwm.c
+++ b/src/bspwm.c
@@ -310,7 +310,9 @@ int main(int argc, char *argv[])
 		rargv[rargc + 3] = sock_fd_arg;
 		rargv[rargc + 4] = 0;
 
-		exit_status = execvp(*rargv, rargv);
+		execvp(*rargv, rargv);
+
+		exit_status = 1;
 		free(rargv);
 	}
 


### PR DESCRIPTION
bspwm uses execvp() to replace itself with a new instance in response to "wm -r", and exits with the return value of that execvp() call if it fails.

execvp() only returns when it fails; and, when it returns, it always returns -1 which is not a valid exit code (it is treated as 255: &0xff).

The return value of execvp() is not really meaningful; let's just exit with `1' if execvp() fails.