### PR TITLE
Remove non-needed Zero initializer

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -152,10 +152,9 @@ char *mktempfifo(const char *template)
 
 int asprintf(char **buf, const char *fmt, ...)
 {
-	int size = 0;
 	va_list args;
 	va_start(args, fmt);
-	size = vasprintf(buf, fmt, args);
+	int size = vasprintf(buf, fmt, args);
 	va_end(args);
 	return size;
 }


### PR DESCRIPTION
This Zero initializer is not needed here. simply initializing it to its needed value will produce slightly better assembly code. asprintf is only ever called twice (at the time of writing) but probably gets called often, so the more efficient the code can be, the better.