### PR TITLE
Add bspc command ('focus') to focus the window under pointer

### DIFF
--- a/src/messages.c
+++ b/src/messages.c
@@ -104,6 +104,8 @@ void process_message(char **args, int num, FILE *rsp)
 		cmd_config(++args, --num, rsp);
 	} else if (streq("quit", *args)) {
 		cmd_quit(++args, --num, rsp);
+	} else if (streq("focus", *args)) {
+		grab_pointer(ACTION_FOCUS);
 	} else {
 		fail(rsp, "Unknown domain or command: '%s'.\n", *args);
 	}


### PR DESCRIPTION
Hi,
I have created that new command to simply focus the window under the pointer (when one is not using focus_follows_pointer option).

I have a (quite simple) use case that wasn't possible to implement correctly without this patch: I want to close window(s) by SUPER+midle_click on them. I don't want the current focused window to be closed but the window directly under the pointer.

Even trying hard in sxhkdrc I couldn't get it to work properly, consider these attempts:

1)
super + button2
  bspc node -c
=> Close the currently focused window (not necessarily under pointer). Practically I was often closing the wrong window because the one under pointer wasn't focused and it's very annoying to click once to focus and once to close

2)
super + button2
  xdotool click --clearmodifiers 1; bspc node -c
=> xdotool doesn't work properly because we are already «inside» a click with button2

3)
super + @button2
  xdotool click --clearmodifiers 1; bspc node -c
=> Seems to work but there is a race condition if we release SUPER too fast, SUPER can be re-enabled by xdotool (SUPER is stuck even if the key was released), this is the bug described here: https://github.com/jordansissel/xdotool/issues/43

4)
super + @button2
  xdotool click --clearmodifiers 1; bspc node -c; xdotool keyup Super_L Super_R=> Workaround the problem in 3) but now SUPER is removed even if the key is still pressed on the keyboard, so we can't chain close multiple windows that way or use another SUPER combination

5) With this patch
super + button2
  bspc focus; bspc node -c

I think this is a useful addition that permits to easily cover some common use cases.
Best,
Lorenzo
