### PR TITLE
When resizing diagonally, adjust ratios for both fences

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -574,6 +574,7 @@ bool resize_client(coordinates_t *loc, resize_handle_t rh, int dx, int dy, bool 
 			sr = MAX(0, sr);
 			sr = MIN(1, sr);
 			vertical_fence->split_ratio = sr;
+			adjust_ratios(vertical_fence, vertical_fence->rectangle);
 		}
 		if (horizontal_fence != NULL) {
 			double sr = 0.0;
@@ -585,9 +586,8 @@ bool resize_client(coordinates_t *loc, resize_handle_t rh, int dx, int dy, bool 
 			sr = MAX(0, sr);
 			sr = MIN(1, sr);
 			horizontal_fence->split_ratio = sr;
+			adjust_ratios(horizontal_fence, horizontal_fence->rectangle);
 		}
-		node_t *target_fence = horizontal_fence != NULL ? horizontal_fence : vertical_fence;
-		adjust_ratios(target_fence, target_fence->rectangle);
 		arrange(loc->monitor, loc->desktop);
 	} else {
 		int w = width, h = height;


### PR DESCRIPTION
Instead of adjusting ratios only for the horizontal fence.

---

From this state:
```
+---+---+---------+
|   |   |         |             1
|   |   |    C    |          /     \
|   |   |         |         2       3
| A | B +-----+---+        / \     / \
|   |   |     |   |       A   B   C   4
|   |   |  D  | E |                  / \
|   |   |     |   |                 D   E
+---+---+-----+---+
```

Resizing D diagonally (`top_left`) would not adjust any ratio. Only resizing it horizontally (`left`) would.

This can be reproduced with `bspc node D -z left -128 0` vs `bspc node D -z top_left -128 -128` (or even `bspc node D -z top_left -128 0`).

It can also be reproduced by starting the `resize_corner` pointer action from node B (`right`) vs starting it from C (`bottom_lefŧ`).

Video of the bug being reproduced on the master branch (527864d8716462e52f85a419f97a776c0643a68c)

https://user-images.githubusercontent.com/20175435/216805549-cedc3b37-5ff2-45ae-b858-5fac76860f7c.mp4

