### PR TITLE
allow setting `honor_size_hints` to `floating` and `tiled`

### DIFF
--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -632,7 +632,7 @@ rule 'COMMANDS'
 Commands
 ^^^^^^^^
 
-*-a*, *--add* (<class_name>|\*)[:(<instance_name>|\*)[:(<name>|\*)]] [*-o*|*--one-shot*] [monitor=MONITOR_SEL|desktop=DESKTOP_SEL|node=NODE_SEL] [state=STATE] [layer=LAYER] [split_dir=DIR] [split_ratio=RATIO] [(hidden|sticky|private|locked|marked|center|follow|manage|focus|border)=(on|off)] [rectangle=WxH+X+Y]::
+*-a*, *--add* (<class_name>|\*)[:(<instance_name>|\*)[:(<name>|\*)]] [*-o*|*--one-shot*] [monitor=MONITOR_SEL|desktop=DESKTOP_SEL|node=NODE_SEL] [state=STATE] [layer=LAYER] [honor_size_hints=(true|false|tiled|floating)] [split_dir=DIR] [split_ratio=RATIO] [(hidden|sticky|private|locked|marked|center|follow|manage|focus|border)=(on|off)] [rectangle=WxH+X+Y]::
 	Create a new rule. Colons in the 'instance_name', 'class_name', or 'name'
 	fields can be escaped with a backslash.
 
@@ -786,9 +786,6 @@ Global Settings
 'center_pseudo_tiled'::
 	Center pseudo tiled windows into their tiling rectangles. Defaults to 'true'.
 
-'honor_size_hints'::
-	If 'true', apply ICCCM window size hints to all windows. If 'floating', only apply them to floating and pseudo tiled windows. If 'tiled', only apply them to tiled windows. If 'false', don't apply them. Defaults to 'false'.
-
 'remove_disabled_monitors'::
 	Consider disabled monitors as disconnected.
 
@@ -818,6 +815,9 @@ Node Settings
 
 'border_width'::
 	Window border width.
+
+'honor_size_hints'::
+	If 'true', apply ICCCM window size hints to all windows. If 'floating', only apply them to floating and pseudo tiled windows. If 'tiled', only apply them to tiled windows. If 'false', don't apply them. Defaults to 'false'.
 
 Pointer Bindings
 ----------------

--- a/doc/bspwm.1.asciidoc
+++ b/doc/bspwm.1.asciidoc
@@ -787,7 +787,7 @@ Global Settings
 	Center pseudo tiled windows into their tiling rectangles. Defaults to 'true'.
 
 'honor_size_hints'::
-	Apply ICCCM window size hints.
+	If 'true', apply ICCCM window size hints to all windows. If 'floating', only apply them to floating and pseudo tiled windows. If 'tiled', only apply them to tiled windows. If 'false', don't apply them. Defaults to 'false'.
 
 'remove_disabled_monitors'::
 	Consider disabled monitors as disconnected.

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -54,10 +54,20 @@
 #define STATE_STR(A)      ((A) == STATE_TILED ? "tiled" : ((A) == STATE_FLOATING ? "floating" : ((A) == STATE_FULLSCREEN ? "fullscreen" : "pseudo_tiled")))
 #define STATE_CHR(A)      ((A) == STATE_TILED ? 'T' : ((A) == STATE_FLOATING ? 'F' : ((A) == STATE_FULLSCREEN ? '=' : 'P')))
 #define LAYER_STR(A)      ((A) == LAYER_BELOW ? "below" : ((A) == LAYER_NORMAL ? "normal" : "above"))
+#define HSH_MODE_STR(A)   ((A) == HONOR_SIZE_HINTS_TILED ? "tiled" : ((A) == HONOR_SIZE_HINTS_FLOATING ? "floating" : BOOL_STR(A)))
 
 #define XCB_CONFIG_WINDOW_X_Y               (XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y)
 #define XCB_CONFIG_WINDOW_WIDTH_HEIGHT      (XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT)
 #define XCB_CONFIG_WINDOW_X_Y_WIDTH_HEIGHT  (XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT)
+
+#define SHOULD_HONOR_SIZE_HINTS(hsh, state) \
+	((hsh) && \
+	 (((hsh) == HONOR_SIZE_HINTS_YES && \
+	   (state) != STATE_FULLSCREEN) || \
+	  ((hsh) == HONOR_SIZE_HINTS_TILED && \
+	   (state) == STATE_TILED) || \
+	  ((hsh) == HONOR_SIZE_HINTS_FLOATING && \
+	   ((state) == STATE_FLOATING || (state) == STATE_PSEUDO_TILED))))
 
 #define MAXLEN    256
 #define SMALEN     32

--- a/src/messages.c
+++ b/src/messages.c
@@ -1638,6 +1638,13 @@ void set_setting(coordinates_t loc, char *name, char *value, FILE *rsp)
 			fail(rsp, "config: %s: Invalid value: '%s'.\n", name, value);
 			return;
 		}
+	} else if (streq("honor_size_hints", name)) {
+		honor_size_hints_mode_t hsh;
+		if (!parse_honor_size_hints_mode(value, &hsh)) {
+			fail(rsp, "config: %s: Invalid value: '%s'.\n", name, value);
+			return;
+		}
+		honor_size_hints = hsh;
 	} else if (streq("mapping_events_count", name)) {
 		if (sscanf(value, "%" SCNi8, &mapping_events_count) != 1) {
 			fail(rsp, "config: %s: Invalid value: '%s'.\n", name, value);
@@ -1753,7 +1760,6 @@ void set_setting(coordinates_t loc, char *name, char *value, FILE *rsp)
 		SET_BOOL(ignore_ewmh_focus)
 		SET_BOOL(ignore_ewmh_struts)
 		SET_BOOL(center_pseudo_tiled)
-		SET_BOOL(honor_size_hints)
 		SET_BOOL(removal_adjustment)
 #undef SET_BOOL
 #define SET_MON_BOOL(s) \
@@ -1844,6 +1850,8 @@ void get_setting(coordinates_t loc, char *name, FILE* rsp)
 		fprintf(rsp, "%s", CHILD_POL_STR(initial_polarity));
 	} else if (streq("automatic_scheme", name)) {
 		fprintf(rsp, "%s", AUTO_SCM_STR(automatic_scheme));
+	} else if (streq("honor_size_hints", name)) {
+		fprintf(rsp, "%s", HSH_MODE_STR(honor_size_hints));
 	} else if (streq("mapping_events_count", name)) {
 		fprintf(rsp, "%" PRIi8, mapping_events_count);
 	} else if (streq("directional_focus_tightness", name)) {
@@ -1884,7 +1892,6 @@ void get_setting(coordinates_t loc, char *name, FILE* rsp)
 	GET_BOOL(ignore_ewmh_focus)
 	GET_BOOL(ignore_ewmh_struts)
 	GET_BOOL(center_pseudo_tiled)
-	GET_BOOL(honor_size_hints)
 	GET_BOOL(removal_adjustment)
 	GET_BOOL(remove_disabled_monitors)
 	GET_BOOL(remove_unplugged_monitors)

--- a/src/parse.c
+++ b/src/parse.c
@@ -282,6 +282,22 @@ bool parse_automatic_scheme(char *s, automatic_scheme_t *a)
 	return false;
 }
 
+bool parse_honor_size_hints_mode(char *s, honor_size_hints_mode_t *a)
+{
+	bool b;
+	if (parse_bool(s, &b)) {
+		*a = b ? HONOR_SIZE_HINTS_YES : HONOR_SIZE_HINTS_NO;
+		return true;
+	} else if (streq("floating", s)) {
+		*a = HONOR_SIZE_HINTS_FLOATING;
+		return true;
+	} else if (streq("tiled", s)) {
+		*a = HONOR_SIZE_HINTS_TILED;
+		return true;
+	}
+	return false;
+}
+
 bool parse_state_transition(char *s, state_transition_t *m)
 {
 	if (streq("none", s)) {

--- a/src/parse.h
+++ b/src/parse.h
@@ -26,6 +26,7 @@ bool parse_button_index(char *s, int8_t *b);
 bool parse_pointer_action(char *s, pointer_action_t *a);
 bool parse_child_polarity(char *s, child_polarity_t *p);
 bool parse_automatic_scheme(char *s, automatic_scheme_t *a);
+bool parse_honor_size_hints_mode(char *s, honor_size_hints_mode_t *a);
 bool parse_state_transition(char *s, state_transition_t *m);
 bool parse_tightness(char *s, tightness_t *t);
 bool parse_degree(char *s, int *d);

--- a/src/pointer.c
+++ b/src/pointer.c
@@ -290,7 +290,7 @@ void track_pointer(coordinates_t loc, pointer_action_t pac, xcb_point_t pos)
 				move_client(&loc, dx, dy);
 			} else if (n) {
 				client_t *c = n->client;
-				if (c && SHOULD_HONOR_SIZE_HINTS(honor_size_hints, c->state)) {
+				if (c && SHOULD_HONOR_SIZE_HINTS(c->honor_size_hints, c->state)) {
 					resize_client(&loc, rh, e->root_x, e->root_y, false);
 				} else {
 					resize_client(&loc, rh, dx, dy, true);

--- a/src/pointer.c
+++ b/src/pointer.c
@@ -288,8 +288,9 @@ void track_pointer(coordinates_t loc, pointer_action_t pac, xcb_point_t pos)
 			int16_t dy = e->root_y - last_motion_y;
 			if (pac == ACTION_MOVE) {
 				move_client(&loc, dx, dy);
-			} else {
-				if (honor_size_hints) {
+			} else if (n) {
+				client_t *c = n->client;
+				if (c && SHOULD_HONOR_SIZE_HINTS(honor_size_hints, c->state)) {
 					resize_client(&loc, rh, e->root_x, e->root_y, false);
 				} else {
 					resize_client(&loc, rh, dx, dy, true);

--- a/src/query.c
+++ b/src/query.c
@@ -455,10 +455,11 @@ void print_rule_consequence(char **buf, rule_consequence_t *csq)
 		*rect_buf = '\0';
 	}
 
-	asprintf(buf, "monitor=%s desktop=%s node=%s state=%s layer=%s split_dir=%s split_ratio=%lf hidden=%s sticky=%s private=%s locked=%s marked=%s center=%s follow=%s manage=%s focus=%s border=%s rectangle=%s",
+	asprintf(buf, "monitor=%s desktop=%s node=%s state=%s layer=%s honor_size_hints=%s split_dir=%s split_ratio=%lf hidden=%s sticky=%s private=%s locked=%s marked=%s center=%s follow=%s manage=%s focus=%s border=%s rectangle=%s",
 	        csq->monitor_desc, csq->desktop_desc, csq->node_desc,
 	        csq->state == NULL ? "" : STATE_STR(*csq->state),
 	        csq->layer == NULL ? "" : LAYER_STR(*csq->layer),
+	        csq->honor_size_hints == HONOR_SIZE_HINTS_DEFAULT ? "" : HSH_MODE_STR(csq->honor_size_hints),
 	        csq->split_dir == NULL ? "" : SPLIT_DIR_STR(*csq->split_dir), csq->split_ratio,
 	        ON_OFF_STR(csq->hidden), ON_OFF_STR(csq->sticky), ON_OFF_STR(csq->private),
 	        ON_OFF_STR(csq->locked), ON_OFF_STR(csq->marked), ON_OFF_STR(csq->center), ON_OFF_STR(csq->follow),

--- a/src/rule.c
+++ b/src/rule.c
@@ -124,6 +124,7 @@ rule_consequence_t *make_rule_consequence(void)
 	rc->layer = NULL;
 	rc->state = NULL;
 	rc->rect = NULL;
+	rc->honor_size_hints = HONOR_SIZE_HINTS_DEFAULT;
 	return rc;
 }
 
@@ -432,6 +433,10 @@ void parse_key_value(char *key, char *value, rule_consequence_t *csq)
 		if (!parse_rectangle(value, csq->rect)) {
 			free(csq->rect);
 			csq->rect = NULL;
+		}
+	} else if (streq("honor_size_hints", key)) {
+		if (!parse_honor_size_hints_mode(value, &csq->honor_size_hints)) {
+			csq->honor_size_hints = HONOR_SIZE_HINTS_DEFAULT;
 		}
 	} else if (parse_bool(value, &v)) {
 		if (streq("hidden", key)) {

--- a/src/settings.c
+++ b/src/settings.c
@@ -67,7 +67,7 @@ bool ignore_ewmh_struts;
 state_transition_t ignore_ewmh_fullscreen;
 
 bool center_pseudo_tiled;
-bool honor_size_hints;
+honor_size_hints_mode_t honor_size_hints;
 
 bool remove_disabled_monitors;
 bool remove_unplugged_monitors;

--- a/src/settings.h
+++ b/src/settings.h
@@ -61,7 +61,7 @@
 #define IGNORE_EWMH_STRUTS          false
 
 #define CENTER_PSEUDO_TILED         true
-#define HONOR_SIZE_HINTS            false
+#define HONOR_SIZE_HINTS            HONOR_SIZE_HINTS_NO
 #define MAPPING_EVENTS_COUNT        1
 
 #define REMOVE_DISABLED_MONITORS    false
@@ -107,7 +107,7 @@ extern bool ignore_ewmh_struts;
 extern state_transition_t ignore_ewmh_fullscreen;
 
 extern bool center_pseudo_tiled;
-extern bool honor_size_hints;
+extern honor_size_hints_mode_t honor_size_hints;
 
 extern bool remove_disabled_monitors;
 extern bool remove_unplugged_monitors;

--- a/src/tree.c
+++ b/src/tree.c
@@ -752,6 +752,7 @@ client_t *make_client(void)
 	c->icccm_props.take_focus = false;
 	c->icccm_props.delete_window = false;
 	c->size_hints.flags = 0;
+	c->honor_size_hints = honor_size_hints;
 	return c;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -54,7 +54,8 @@ typedef enum {
 	HONOR_SIZE_HINTS_NO = 0,
 	HONOR_SIZE_HINTS_YES,
 	HONOR_SIZE_HINTS_FLOATING,
-	HONOR_SIZE_HINTS_TILED
+	HONOR_SIZE_HINTS_TILED,
+	HONOR_SIZE_HINTS_DEFAULT
 } honor_size_hints_mode_t;
 
 typedef enum {
@@ -231,6 +232,7 @@ typedef struct {
 	stack_layer_t last_layer;
 	xcb_rectangle_t floating_rectangle;
 	xcb_rectangle_t tiled_rectangle;
+	honor_size_hints_mode_t honor_size_hints;
 	xcb_size_hints_t size_hints;
 	icccm_props_t icccm_props;
 	wm_flags_t wm_flags;
@@ -371,6 +373,7 @@ typedef struct {
 	double split_ratio;
 	stack_layer_t *layer;
 	client_state_t *state;
+	honor_size_hints_mode_t honor_size_hints;
 	bool hidden;
 	bool sticky;
 	bool private;

--- a/src/types.h
+++ b/src/types.h
@@ -51,6 +51,13 @@ typedef enum {
 } automatic_scheme_t;
 
 typedef enum {
+	HONOR_SIZE_HINTS_NO = 0,
+	HONOR_SIZE_HINTS_YES,
+	HONOR_SIZE_HINTS_FLOATING,
+	HONOR_SIZE_HINTS_TILED
+} honor_size_hints_mode_t;
+
+typedef enum {
 	STATE_TILED,
 	STATE_PSEUDO_TILED,
 	STATE_FLOATING,

--- a/src/window.c
+++ b/src/window.c
@@ -185,6 +185,10 @@ bool manage_window(xcb_window_t win, rule_consequence_t *csq, int fd)
 		set_state(m, d, n, *(csq->state));
 	}
 
+	if (csq->honor_size_hints != HONOR_SIZE_HINTS_DEFAULT) {
+		c->honor_size_hints = csq->honor_size_hints;
+	}
+
 	set_hidden(m, d, n, csq->hidden);
 	set_sticky(m, d, n, csq->sticky);
 	set_private(m, d, n, csq->private);
@@ -632,7 +636,7 @@ bool resize_client(coordinates_t *loc, resize_handle_t rh, int dx, int dy, bool 
 /* taken from awesomeWM */
 void apply_size_hints(client_t *c, uint16_t *width, uint16_t *height)
 {
-	if (!SHOULD_HONOR_SIZE_HINTS(honor_size_hints, c->state)) {
+	if (!SHOULD_HONOR_SIZE_HINTS(c->honor_size_hints, c->state)) {
 		return;
 	}
 

--- a/src/window.c
+++ b/src/window.c
@@ -632,16 +632,12 @@ bool resize_client(coordinates_t *loc, resize_handle_t rh, int dx, int dy, bool 
 /* taken from awesomeWM */
 void apply_size_hints(client_t *c, uint16_t *width, uint16_t *height)
 {
-	if (!honor_size_hints) {
+	if (!SHOULD_HONOR_SIZE_HINTS(honor_size_hints, c->state)) {
 		return;
 	}
 
 	int32_t minw = 0, minh = 0;
 	int32_t basew = 0, baseh = 0, real_basew = 0, real_baseh = 0;
-
-	if (c->state == STATE_FULLSCREEN) {
-		return;
-	}
 
 	if (c->size_hints.flags & XCB_ICCCM_SIZE_HINT_BASE_SIZE) {
 		basew = c->size_hints.base_width;


### PR DESCRIPTION
The first commit allows setting the `honor_size_hints` setting to `floating` or `tiled`.
* If you set it to `floating`, bspwm will only honour size hints for floating and pseudo tiled windows.
* If you set it to `tiled`, bspwm will only honour size hints for tiled windows.
* If you set it to `true`/`on`, as before, it will honour size hints for every non-fullscreen window.
* If you set it to `false`/`off`, as before, it will not honour size hints for any window.

The second commit turns `honor_size_hints` into a node setting with a global default value.
This lets you selectively enable/disable/enable only for tiled windows/enable only for non-tiled windows the honouring of size hints either using a rule with `honor_size_hints=FOO`, or using a `config -n NODE_SEL honor_size_hints FOO` command to change `honor_size_hints` for one specific window.

Fixes #1447 