### PR TITLE
Exec bspwmrc before setting up signal handlers.

### DIFF
--- a/src/bspwm.c
+++ b/src/bspwm.c
@@ -194,12 +194,12 @@ int main(int argc, char *argv[])
 
 	fcntl(sock_fd, F_SETFD, FD_CLOEXEC | fcntl(sock_fd, F_GETFD));
 
+	run_config(run_level);
 	signal(SIGINT, sig_handler);
 	signal(SIGHUP, sig_handler);
 	signal(SIGTERM, sig_handler);
 	signal(SIGCHLD, sig_handler);
 	signal(SIGPIPE, SIG_IGN);
-	run_config(run_level);
 	running = true;
 
 	while (running) {


### PR DESCRIPTION
Before this change, it seems everything I launch via bspwm ignored `SIGPIPE`, which is unexpected.

I have not thoroughly tested this change. I'm currently using bspwm with the change applied and will comment if I run into any trouble.

For example, if I ran `find / | :` (in an xterm launched via sxhkdrc which was launched from bspwmrc) then that command would hang until `find` finished; normally, with `SIGPIPE` having its default effect of terminating the process, `find / | :` should end right away because `find` dies.