### PR TITLE
Revamp signal handling.

### DIFF
--- a/src/bspwm.h
+++ b/src/bspwm.h
@@ -84,7 +84,7 @@ extern bool auto_raise;
 extern bool sticky_still;
 extern bool hide_sticky;
 extern bool record_history;
-extern bool running;
+extern volatile sig_atomic_t running;
 extern bool restart;
 extern bool randr;
 


### PR DESCRIPTION
I ran into a bug related to bspwm's signal handling, and then noticed a couple of other issues, so decided to try redoing it.

The bug: pipes like `find / | :` would hang when launched from bspwm instead of terminating right away. The reason was that bspwm ignores `SIGPIPE`, and that status got passed on to anything launched via `bspwmrc`, through `sxhkdrc`, `xterm`, my shell, all the way through to the `find` process which is supposed to die when its output is cut off.

NB I've only just started testing this change by using it. If there are particular things for me to try out (e.g. the reasons the signal handlers were installed in the first place), let me know.

Details:

- Change from signal to sigaction, which is more portable.

- Install a handler for SIGPIPE instead of ignoring it, to avoid passing on the ignored status to other programs launched from bspwm.

- Use SA_NOCLDWAIT to avoid the need to call waitpid. (NB if waitpid were called in the handler, it would be a good idea to protect errno.)

- Declare the "running" global as volatile sig_atomic_t, as recommended for values modified from signal handlers.