### PR TITLE
Fix gratuitous pointer jump

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -360,7 +360,10 @@ void focus_in(xcb_generic_event_t *evt)
 		if (e->event == root) {
 			/* Some clients expect the window manager to refocus the
 			   focused window in this case */
+			bool pff = pointer_follows_focus;
+			pointer_follows_focus = false;
 			focus_node(mon, mon->desk, mon->desk->focus);
+			pointer_follows_focus = pff;
 			return;
 		}
 	}


### PR DESCRIPTION
I have `pointer_follows_focus` set. Normally when I focus a window by moving the pointer to it, the pointer doesn't warp, which is good: I only want it to warp when something else caused the focus to change. However, if the pointer crossed from one monitor to another, it would warp to the middle of the newly focussed window, which was annoying.

With some debugging I figured out `focus_in` was being triggered with `e->event == root`, causing `focus_in` to focus the focussed node a second time. I don't know enough about X to understand why this event was generated; perhaps a real fix would address that as the root issue (no pun intended).

Instead, this fix simply unsets `pointer_follows_focus` in this case. I briefly tested the repro instructions at https://github.com/baskerville/bspwm/issues/1378#issuecomment-1107700054 to confirm the original bug behind the code I modified did not come back.