### PR TITLE
Persist desktop-specific split ratios

### DIFF
--- a/src/desktop.c
+++ b/src/desktop.c
@@ -248,6 +248,7 @@ desktop_t *make_desktop(const char *name, uint32_t id)
 	d->padding = (padding_t) PADDING;
 	d->window_gap = window_gap;
 	d->border_width = border_width;
+	d->split_ratio = split_ratio;
 	return d;
 }
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -351,7 +351,7 @@ node_t *restore_node(jsmntok_t **t, char *json)
 		int s = (*t)->size;
 		(*t)++;
 		/* hack to prevent a new ID from being generated */
-		node_t *n = make_node(UINT32_MAX);
+		node_t *n = make_node(UINT32_MAX, split_ratio);
 
 		for (int i = 0; i < s; i++) {
 			if (keyeq("id", *t, json)) {

--- a/src/tree.c
+++ b/src/tree.c
@@ -323,7 +323,7 @@ node_t *insert_node(monitor_t *m, desktop_t *d, node_t *n, node_t *f)
 		free(f);
 		f = NULL;
 	} else {
-		node_t *c = make_node(XCB_NONE);
+		node_t *c = make_node(XCB_NONE, d->split_ratio);
 		node_t *p = f->parent;
 		if (f->presel == NULL && (f->private || private_count(f->parent) > 0)) {
 			node_t *k = find_public(d);
@@ -442,6 +442,7 @@ node_t *insert_node(monitor_t *m, desktop_t *d, node_t *n, node_t *f)
 			}
 			if (d->root == f) {
 				d->root = c;
+				d->split_ratio = c->split_ratio;
 			}
 			cancel_presel(m, d, f);
 			set_marked(m, d, n, false);
@@ -463,7 +464,7 @@ node_t *insert_node(monitor_t *m, desktop_t *d, node_t *n, node_t *f)
 
 void insert_receptacle(monitor_t *m, desktop_t *d, node_t *n)
 {
-	node_t *r = make_node(XCB_NONE);
+	node_t *r = make_node(XCB_NONE, d->split_ratio);
 	insert_node(m, d, r, n);
 	put_status(SBSC_MASK_NODE_ADD, "node_add 0x%08X 0x%08X 0x%08X 0x%08X\n", m->id, d->id, n != NULL ? n->id : 0, r->id);
 
@@ -726,7 +727,7 @@ void show_node(desktop_t *d, node_t *n)
 	}
 }
 
-node_t *make_node(uint32_t id)
+node_t *make_node(uint32_t id, double sr)
 {
 	if (id == XCB_NONE) {
 		id = xcb_generate_id(dpy);
@@ -735,7 +736,7 @@ node_t *make_node(uint32_t id)
 	n->id = id;
 	n->parent = n->first_child = n->second_child = NULL;
 	n->vacant = n->hidden = n->sticky = n->private = n->locked = n->marked = false;
-	n->split_ratio = split_ratio;
+	n->split_ratio = sr;
 	n->split_type = TYPE_VERTICAL;
 	n->constraints = (constraints_t) {MIN_WIDTH, MIN_HEIGHT};
 	n->presel = NULL;

--- a/src/tree.h
+++ b/src/tree.h
@@ -45,7 +45,7 @@ void transfer_sticky_nodes(monitor_t *ms, desktop_t *ds, monitor_t *md, desktop_
 bool focus_node(monitor_t *m, desktop_t *d, node_t *n);
 void hide_node(desktop_t *d, node_t *n);
 void show_node(desktop_t *d, node_t *n);
-node_t *make_node(uint32_t id);
+node_t *make_node(uint32_t id, double sr);
 client_t *make_client(void);
 void initialize_client(node_t *n);
 bool is_focusable(node_t *n);

--- a/src/types.h
+++ b/src/types.h
@@ -283,6 +283,7 @@ typedef struct desktop_t desktop_t;
 struct desktop_t {
 	char name[SMALEN];
 	uint32_t id;
+	double split_ratio;
 	layout_t layout;
 	layout_t user_layout;
 	node_t *root;

--- a/src/window.c
+++ b/src/window.c
@@ -134,7 +134,7 @@ bool manage_window(xcb_window_t win, rule_consequence_t *csq, int fd)
 		presel_ratio(m, d, f, csq->split_ratio);
 	}
 
-	node_t *n = make_node(win);
+	node_t *n = make_node(win, d->split_ratio);
 	client_t *c = make_client();
 	c->border_width = csq->border ? d->border_width : 0;
 	n->client = c;
@@ -547,6 +547,7 @@ bool move_client(coordinates_t *loc, int dx, int dy)
 bool resize_client(coordinates_t *loc, resize_handle_t rh, int dx, int dy, bool relative)
 {
 	node_t *n = loc->node;
+	desktop_t *d = loc->desktop;
 	if (n == NULL || n->client == NULL || n->client->state == STATE_FULLSCREEN) {
 		return false;
 	}
@@ -577,6 +578,9 @@ bool resize_client(coordinates_t *loc, resize_handle_t rh, int dx, int dy, bool 
 			}
 			sr = MAX(0, sr);
 			sr = MIN(1, sr);
+			if (d->root == vertical_fence) {
+				d->split_ratio = sr;
+			}
 			vertical_fence->split_ratio = sr;
 			adjust_ratios(vertical_fence, vertical_fence->rectangle);
 		}
@@ -589,6 +593,9 @@ bool resize_client(coordinates_t *loc, resize_handle_t rh, int dx, int dy, bool 
 			}
 			sr = MAX(0, sr);
 			sr = MIN(1, sr);
+			if (vertical_fence == NULL && d->root == horizontal_fence) {
+				d->split_ratio = sr;
+			}
 			horizontal_fence->split_ratio = sr;
 			adjust_ratios(horizontal_fence, horizontal_fence->rectangle);
 		}


### PR DESCRIPTION
This update adds the ability to retain the split_ratio in memory for each desktop. 
Changes made:
- Update the desktop's split_ratio when changes affect the root.
- Prioritize the vertical_fence split_ratio during resizing that involves both horizontal and vertical adjustments.
- Update the desktop's split_ratio with the preselection split_ratio if preselected node is the root.