### PR TITLE
Set desktop name in xsession file

### DIFF
--- a/contrib/freedesktop/bspwm.desktop
+++ b/contrib/freedesktop/bspwm.desktop
@@ -3,3 +3,4 @@ Name=bspwm
 Comment=Binary space partitioning window manager
 Exec=bspwm
 Type=Application
+DesktopNames=bspwm


### PR DESCRIPTION
This will allow session managers to automatically set $XDG_CURRENT_DESKTOP. In particular, I'm interested in this because it allows .desktop file keys like "OnlyShowIn" and "NotShowIn" to be taken into account for BSPWM when using application launchers like rofi.