### PR TITLE
_NET_WM_WINDOW_TYPE_UTILITY windows should float

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -234,9 +234,11 @@ void _apply_window_type(xcb_window_t win, rule_consequence_t *csq)
 	if (xcb_ewmh_get_wm_window_type_reply(ewmh, xcb_ewmh_get_wm_window_type(ewmh, win), &win_type, NULL) == 1) {
 		for (unsigned int i = 0; i < win_type.atoms_len; i++) {
 			xcb_atom_t a = win_type.atoms[i];
-			if (a == ewmh->_NET_WM_WINDOW_TYPE_TOOLBAR ||
-			    a == ewmh->_NET_WM_WINDOW_TYPE_UTILITY) {
+			if (a == ewmh->_NET_WM_WINDOW_TYPE_TOOLBAR) {
 				csq->focus = false;
+			} else if (a == ewmh->_NET_WM_WINDOW_TYPE_UTILITY) {
+				csq->focus = false;
+				SET_CSQ_STATE(STATE_FLOATING);
 			} else if (a == ewmh->_NET_WM_WINDOW_TYPE_DIALOG) {
 				SET_CSQ_STATE(STATE_FLOATING);
 				csq->center = true;


### PR DESCRIPTION
According to:
https://specifications.freedesktop.org/wm-spec/1.5/ar01s05.html

>_NET_WM_WINDOW_TYPE_UTILITY indicates a small persistent utility
window, such as a palette or toolbox. It is distinct from type TOOLBAR because it does not correspond to a toolbar torn off from the main application. It's distinct from type DIALOG because it isn't a transient dialog, the user will probably keep it open while they're working. Windows of this type may set the WM_TRANSIENT_FOR hint indicating the main application window.

This seems to indicate that this windows should start floating by default, as one would expect of either a "palette" or a "toolbox".

Specifically, this has implications for Picture-In-Picture windows in chromium.