### PR TITLE
Allow for boundary distance to be negative for overlapping windows

### DIFF
--- a/src/geometry.c
+++ b/src/geometry.c
@@ -46,25 +46,26 @@ unsigned int area(xcb_rectangle_t r)
 }
 
 /* Distance between the `dir` edge of `r1` and the `opposite(dir)` edge of `r2`. */
-uint32_t boundary_distance(xcb_rectangle_t r1, xcb_rectangle_t r2, direction_t dir)
+int32_t boundary_distance(xcb_rectangle_t r1, xcb_rectangle_t r2, direction_t dir)
 {
 	xcb_point_t r1_max = {r1.x + r1.width - 1, r1.y + r1.height - 1};
 	xcb_point_t r2_max = {r2.x + r2.width - 1, r2.y + r2.height - 1};
+
 	switch (dir) {
 		case DIR_NORTH:
-			return r2_max.y > r1.y ? r2_max.y - r1.y : r1.y - r2_max.y;
-			break;
+                        return r1.y - r2_max.y;
+                        break;
 		case DIR_WEST:
-			return r2_max.x > r1.x ? r2_max.x - r1.x : r1.x - r2_max.x;
-			break;
+                        return r1.x - r2_max.x;
+                        break;
 		case DIR_SOUTH:
-			return r2.y < r1_max.y ? r1_max.y - r2.y : r2.y - r1_max.y;
-			break;
+                        return r2.y - r1_max.y;
+                        break;
 		case DIR_EAST:
-			return r2.x < r1_max.x ? r1_max.x - r2.x : r2.x - r1_max.x;
-			break;
+                        return r2.x - r1_max.x;
+                        break;
 		default:
-			return UINT32_MAX;
+			return INT32_MAX;
 	}
 }
 

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -31,7 +31,7 @@
 bool is_inside(xcb_point_t p, xcb_rectangle_t r);
 bool contains(xcb_rectangle_t a, xcb_rectangle_t b);
 unsigned int area(xcb_rectangle_t r);
-uint32_t boundary_distance(xcb_rectangle_t r1, xcb_rectangle_t r2, direction_t dir);
+int32_t boundary_distance(xcb_rectangle_t r1, xcb_rectangle_t r2, direction_t dir);
 bool on_dir_side(xcb_rectangle_t r1, xcb_rectangle_t r2, direction_t dir);
 bool rect_eq(xcb_rectangle_t a, xcb_rectangle_t b);
 int rect_cmp(xcb_rectangle_t r1, xcb_rectangle_t r2);

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -406,7 +406,7 @@ monitor_t *monitor_from_client(client_t *c)
 
 monitor_t *nearest_monitor(monitor_t *m, direction_t dir, monitor_select_t *sel)
 {
-	uint32_t dmin = UINT32_MAX;
+	int32_t dmin = INT32_MAX;
 	monitor_t *nearest = NULL;
 	xcb_rectangle_t rect = m->rectangle;
 	for (monitor_t *f = mon_head; f != NULL; f = f->next) {
@@ -417,7 +417,7 @@ monitor_t *nearest_monitor(monitor_t *m, direction_t dir, monitor_select_t *sel)
 		    !on_dir_side(rect, r, dir)) {
 			continue;
 		}
-		uint32_t d = boundary_distance(rect, r, dir);
+		int32_t d = boundary_distance(rect, r, dir);
 		if (d < dmin) {
 			dmin = d;
 			nearest = f;

--- a/src/tree.c
+++ b/src/tree.c
@@ -1124,7 +1124,8 @@ void find_first_ancestor(coordinates_t *ref, coordinates_t *dst, node_select_t *
 void find_nearest_neighbor(coordinates_t *ref, coordinates_t *dst, direction_t dir, node_select_t *sel)
 {
 	xcb_rectangle_t rect = get_rectangle(ref->monitor, ref->desktop, ref->node);
-	uint32_t md = UINT32_MAX, mr = UINT32_MAX;
+	int32_t md = INT32_MAX;
+	uint32_t mr = UINT32_MAX;
 
 	for (monitor_t *m = mon_head; m != NULL; m = m->next) {
 		desktop_t *d = m->desk;
@@ -1139,7 +1140,7 @@ void find_nearest_neighbor(coordinates_t *ref, coordinates_t *dst, direction_t d
 			    !on_dir_side(rect, r, dir)) {
 				continue;
 			}
-			uint32_t fd = boundary_distance(rect, r, dir);
+			int32_t fd = boundary_distance(rect, r, dir);
 			uint32_t fr = history_rank(f);
 			if (fd < md || (fd == md && fr < mr)) {
 				md = fd;


### PR DESCRIPTION
In a layouts like so:
```
     +----------+
     |          |  +----------+
     |    W3+------|          |
     |      |      |    W1    |
     +------|    W2|          |
            |      +----------+
            +----------+
                |  |   |
           w3_max  w1  w2_max
```
Switching from focused `W1` to the west will switch to the `W3`  despite `W2` being visually closer. It happens because the absolute distance `w3_max - w1` is less than `w2_max - w1`. <br></br>
Allowing for distance to be negative solves the problem: negative values are preferred by the search algorithm and the closer the overlapping windows are, the lesser the negative distance becomes, allowing to switch to the closest overlapping window if there are many.