### PR TITLE
Fix segfault caused by non-null-terminated string.

### DIFF
--- a/src/rule.c
+++ b/src/rule.c
@@ -307,7 +307,7 @@ void _apply_name(xcb_window_t win, rule_consequence_t *csq)
 {
 	xcb_icccm_get_text_property_reply_t reply;
 	if (xcb_icccm_get_wm_name_reply(dpy, xcb_icccm_get_wm_name(dpy, win), &reply, NULL) == 1) {
-		snprintf(csq->name, sizeof(csq->name), "%s", reply.name);
+		snprintf(csq->name, sizeof(csq->name), "%.*s", reply.name_len, reply.name);
 		xcb_icccm_get_text_property_reply_wipe(&reply);
 	}
 }


### PR DESCRIPTION
I got the printf %.*s idea from xcb documentation somewhere but now I can't find it.

Fixes #1503

Hopefully this is the only case. I searched for `xcb_` in the source and gave the results a cursory look.