### PR TITLE
Fix floating window border offset bug in configure_request

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -151,11 +151,11 @@ void configure_request(xcb_generic_event_t *evt)
 		height = c->floating_rectangle.height;
 
 		if (e->value_mask & XCB_CONFIG_WINDOW_X) {
-			c->floating_rectangle.x = e->x;
+			c->floating_rectangle.x = e->x - c->border_width;
 		}
 
 		if (e->value_mask & XCB_CONFIG_WINDOW_Y) {
-			c->floating_rectangle.y = e->y;
+			c->floating_rectangle.y = e->y - c->border_width;
 		}
 
 		if (e->value_mask & XCB_CONFIG_WINDOW_WIDTH) {
@@ -170,9 +170,6 @@ void configure_request(xcb_generic_event_t *evt)
 		c->floating_rectangle.width = width;
 		c->floating_rectangle.height = height;
 		xcb_rectangle_t r = c->floating_rectangle;
-
-		r.x -= c->border_width;
-		r.y -= c->border_width;
 
 		window_move_resize(e->window, r.x, r.y, r.width, r.height);
 


### PR DESCRIPTION
Commit af3bd8b4351f4478fe0fe3cfd6c09e44cb108b4b tried to fix the issue with floating window movement by changing the values passed to window_move_resize, but the actual values of c->floating_rectangle should have also been changed since that structure is expected to hold the coordinates of the outer window including the border.

Screenshots:

A floating window is spawned and placed in the upper right hand corner:
<img width="630" height="308" alt="floating-window-in-corner" src="https://github.com/user-attachments/assets/ad1c0bf5-c5a0-4d8b-a2bf-ea7b84dd08f9" />

A new floating window is spawned while the original window is focused. The floating window moves down and to the right by the size of the border.
<img width="655" height="426" alt="floating-window-moves-after-spawning-new-floating-window" src="https://github.com/user-attachments/assets/3bf7e988-c2f3-480c-83d0-e5a1983009fb" />
